### PR TITLE
Refine five-tile layout with six-by-two grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -790,12 +790,15 @@ function openMatrix() {
 
     // Special mosaics for specific counts
     if (n === 5) {
-      matrixBody.style.gridTemplateColumns = 'repeat(4, minmax(0, 1fr))';
-      matrixBody.style.gridTemplateRows = 'repeat(2, minmax(0, 1fr))';
-      if (tiles[0]) {
-        tiles[0].style.gridColumn = 'span 2';
-        tiles[0].style.gridRow = 'span 2';
-      }
+      // Balanced 6×2 mosaic for five streams
+      matrixBody.style.gridTemplateColumns = 'repeat(6, minmax(0, 1fr))';
+      matrixBody.style.gridTemplateRows    = 'repeat(2, minmax(0, 1fr))';
+
+      if (tiles[0]) tiles[0].style.gridColumn = 'span 3';
+      if (tiles[1]) tiles[1].style.gridColumn = 'span 3';
+      if (tiles[2]) tiles[2].style.gridColumn = 'span 2';
+      if (tiles[3]) tiles[3].style.gridColumn = 'span 2';
+      if (tiles[4]) tiles[4].style.gridColumn = 'span 2';
       return;
     }
 


### PR DESCRIPTION
## Summary
- Use six-column, two-row grid for five-tile layouts.
- Apply explicit column spans for balanced arrangement.

## Testing
- `npm test` (fails: Could not find package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b6f2d46e18833295b3636a7159de51