### PR TITLE
Matrix X-button: show ✓/✖ states, remove static X, and mirror to versions snapshot

### DIFF
--- a/index.html
+++ b/index.html
@@ -272,6 +272,9 @@
       right:6px;
       color:#9ca3af;
       border-radius:4px;
+      font-size:13px;
+      font-weight:700;
+      line-height:1;
     }
     .matrix-blacklist.state-pinned { color:#22c55e; }
     .matrix-blacklist.state-blacklisted { color:#ff5555; }
@@ -1094,14 +1097,17 @@ function setMatrixPinStateButtonStyle(btn, name) {
   btn.classList.remove('state-pinned', 'state-blacklisted');
   if (sessionPins.has(name)) {
     btn.classList.add('state-pinned');
+    btn.textContent = '✓';
     btn.title = 'Pinned (click to clear)';
     return;
   }
   if (sessionBlacklist.has(name)) {
     btn.classList.add('state-blacklisted');
+    btn.textContent = '✖';
     btn.title = 'Blacklisted (click to pin)';
     return;
   }
+  btn.textContent = '';
   btn.title = 'Neutral (click to blacklist)';
 }
 
@@ -1279,7 +1285,6 @@ function openMatrix() {
 
     const xbtn = document.createElement('button');
     xbtn.className = 'matrix-tile-button matrix-blacklist';
-    xbtn.textContent = '✖';
     setMatrixPinStateButtonStyle(xbtn, name);
     xbtn.onclick = () => cycleMatrixTilePinState(tile, xbtn);
 

--- a/versions/twitchmatrixpinfix001.html
+++ b/versions/twitchmatrixpinfix001.html
@@ -272,6 +272,9 @@
       right:6px;
       color:#9ca3af;
       border-radius:4px;
+      font-size:13px;
+      font-weight:700;
+      line-height:1;
     }
     .matrix-blacklist.state-pinned { color:#22c55e; }
     .matrix-blacklist.state-blacklisted { color:#ff5555; }
@@ -1094,14 +1097,17 @@ function setMatrixPinStateButtonStyle(btn, name) {
   btn.classList.remove('state-pinned', 'state-blacklisted');
   if (sessionPins.has(name)) {
     btn.classList.add('state-pinned');
+    btn.textContent = '✓';
     btn.title = 'Pinned (click to clear)';
     return;
   }
   if (sessionBlacklist.has(name)) {
     btn.classList.add('state-blacklisted');
+    btn.textContent = '✖';
     btn.title = 'Blacklisted (click to pin)';
     return;
   }
+  btn.textContent = '';
   btn.title = 'Neutral (click to blacklist)';
 }
 
@@ -1279,7 +1285,6 @@ function openMatrix() {
 
     const xbtn = document.createElement('button');
     xbtn.className = 'matrix-tile-button matrix-blacklist';
-    xbtn.textContent = '✖';
     setMatrixPinStateButtonStyle(xbtn, name);
     xbtn.onclick = () => cycleMatrixTilePinState(tile, xbtn);
 


### PR DESCRIPTION
### Motivation
- Clicking the matrix tile X button did not give a clear visible change, making pin/blacklist actions ambiguous. 
- The UI should match the settings-page style: pinned and blacklisted must show distinct visuals, and neutral should show no symbol. 
- The latest `versions/` snapshot should remain in sync with the live `index.html` behavior.

### Description
- Updated `.matrix-blacklist` CSS to improve symbol legibility by adding `font-size`, `font-weight`, and `line-height` tweaks. 
- Changed `setMatrixPinStateButtonStyle` to render explicit symbols: `✓` for pinned, `✖` for blacklisted, and empty text for neutral, while preserving tooltips. 
- Removed the hardcoded initial `✖` on tile creation so the button always reflects the current state via `setMatrixPinStateButtonStyle`. 
- Applied the same code and style changes to `versions/twitchmatrixpinfix001.html` to keep the snapshot consistent with `index.html`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ddc102d808332ab11ad375f1f6cdf)