### PR TITLE
Await Twitch player readiness before switching channels and simplify matrix tile lifecycle

### DIFF
--- a/index.html
+++ b/index.html
@@ -980,6 +980,7 @@ let matrixRefreshIntervalId = null;
 let matrixCountdownSeconds = 0;
 let matrixResizeHandler = null;
 const matrixPlayers = new WeakMap();
+const matrixPlayerReady = new WeakMap();
 const matrixTilesByName = new Map();
 const matrixTileRefreshTimers = new WeakMap();
 const MATRIX_PLAYER_QUALITY = '360p';
@@ -1012,6 +1013,7 @@ function destroyMatrixTile(tile, { remove = false } = {}) {
   if (player) {
     try { player.pause(); } catch (e) {}
     matrixPlayers.delete(holder);
+    matrixPlayerReady.delete(holder);
   }
   const xbtn = tile.querySelector('.matrix-blacklist');
   if (xbtn) xbtn.onclick = null;
@@ -1046,7 +1048,11 @@ function createMatrixPlayerTile(name) {
     height: '100%',
   };
   const player = new Twitch.Player(holder, opts);
+  const readyState = { ready: false, waiters: [] };
+  matrixPlayerReady.set(holder, readyState);
   player.addEventListener(Twitch.Player.READY, () => {
+    readyState.ready = true;
+    readyState.waiters.splice(0).forEach((resolve) => resolve());
     try { player.setMuted(true); } catch (e) {}
     try { player.setQuality(MATRIX_PLAYER_QUALITY); } catch (e) {}
     try { player.play(); } catch (e) {}
@@ -1055,16 +1061,24 @@ function createMatrixPlayerTile(name) {
   return holder;
 }
 
-function setMatrixTileStream(tile, nextName) {
+async function setMatrixTileStream(tile, nextName) {
   if (!tile || !nextName) return;
   const holder = tile.querySelector('.matrix-player-holder');
   const player = holder ? matrixPlayers.get(holder) : null;
+  const readyState = holder ? matrixPlayerReady.get(holder) : null;
+
   if (player && typeof player.setChannel === 'function') {
-    try { player.setChannel(nextName); } catch (e) {}
+    if (readyState && !readyState.ready) {
+      await new Promise((resolve) => readyState.waiters.push(resolve));
+    }
+    try { player.pause(); } catch (e) {}
+    try { player.setChannel(nextName); } catch (e) { console.warn("setChannel failed", nextName, e); }
     try { player.setMuted(true); } catch (e) {}
     try { player.setQuality(MATRIX_PLAYER_QUALITY); } catch (e) {}
     try { player.play(); } catch (e) {}
+    if (holder) holder.dataset.streamer = nextName;
   }
+
   const prevName = String(tile.dataset.streamer || '').toLowerCase();
   if (prevName) matrixTilesByName.delete(prevName);
   matrixTilesByName.set(String(nextName).toLowerCase(), tile);
@@ -1316,35 +1330,37 @@ function openMatrix() {
     matrixBody.appendChild(warn);
   }
 
-  const desired = new Set((lastLive || []).map(n => String(n).toLowerCase()));
-  Array.from(matrixBody.querySelectorAll('.tile')).forEach((tile) => {
-    const nameLc = String(tile.dataset.streamer || '').toLowerCase();
-    if (!desired.has(nameLc)) destroyMatrixTile(tile, { remove: true });
-  });
-  lastLive.forEach((name) => {
-    const key = String(name).toLowerCase();
-    let tile = matrixTilesByName.get(key);
-    if (!tile) {
-      tile = document.createElement('div');
-      tile.className = 'tile';
-      tile.dataset.streamer = name;
-      const holder = createMatrixPlayerTile(name);
-      const xbtn = document.createElement('button');
-      xbtn.className = 'matrix-tile-button matrix-blacklist';
-      setMatrixPinStateButtonStyle(xbtn, name);
-      xbtn.onclick = () => cycleMatrixTilePinState(tile, xbtn);
-      const nameBadge = document.createElement('button');
-      nameBadge.type = 'button';
-      nameBadge.className = 'matrix-streamer-name';
-      nameBadge.textContent = name;
-      nameBadge.title = 'Change stream';
-      nameBadge.dataset.role = 'matrix-name-picker';
-      tile.append(holder, xbtn, nameBadge);
-      matrixTilesByName.set(key, tile);
-    } else {
-      setMatrixTileStream(tile, name);
-    }
+  const existingTiles = Array.from(matrixBody.querySelectorAll('.tile'));
+  const targetCount = (lastLive || []).length;
+
+  for (let i = existingTiles.length - 1; i >= targetCount; i--) {
+    destroyMatrixTile(existingTiles[i], { remove: true });
+  }
+
+  for (let i = matrixBody.querySelectorAll('.tile').length; i < targetCount; i++) {
+    const name = lastLive[i];
+    const tile = document.createElement('div');
+    tile.className = 'tile';
+    tile.dataset.streamer = name;
+    const holder = createMatrixPlayerTile(name);
+    const xbtn = document.createElement('button');
+    xbtn.className = 'matrix-tile-button matrix-blacklist';
+    setMatrixPinStateButtonStyle(xbtn, name);
+    xbtn.onclick = () => cycleMatrixTilePinState(tile, xbtn);
+    const nameBadge = document.createElement('button');
+    nameBadge.type = 'button';
+    nameBadge.className = 'matrix-streamer-name';
+    nameBadge.textContent = name;
+    nameBadge.title = 'Change stream';
+    nameBadge.dataset.role = 'matrix-name-picker';
+    tile.append(holder, xbtn, nameBadge);
     matrixBody.appendChild(tile);
+  }
+
+  Array.from(matrixBody.querySelectorAll('.tile')).forEach((tile, idx) => {
+    const name = lastLive[idx];
+    if (!name) return;
+    setMatrixTileStream(tile, name);
   });
 
   function optimalCols(n, W, H, gap) {


### PR DESCRIPTION
### Motivation
- Prevent race conditions and errors when calling `player.setChannel` before the Twitch player has emitted `READY` by tracking readiness and queuing waits. 
- Simplify and stabilize the matrix overlay tile creation/removal logic so tiles match `lastLive` ordering and are updated deterministically.

### Description
- Add `matrixPlayerReady` `WeakMap` and per-holder ready state with a `waiters` queue in `createMatrixPlayerTile` and resolve waiters on `Twitch.Player.READY`.
- Make `setMatrixTileStream` asynchronous and `await` the player's ready state before calling `setChannel`, add a `pause` before switching, and surface a `console.warn` on `setChannel` failures, and update `holder.dataset.streamer` after switching.
- Remove the ready state entry when destroying a tile in `destroyMatrixTile`.
- Replace the previous name-based add/remove logic in `openMatrix` with index-based resizing: remove excess tiles, append missing tiles to reach `lastLive.length`, then assign streams to each tile in order via `setMatrixTileStream`.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10eed2745c833284ef3f842aec1a48)