### PR TITLE
Fix Safari matrix iframe disposal and reinit timing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1007,7 +1007,8 @@ function disposeMatrixIframe(iframe, { remove = false } = {}) {
   if (!iframe) return;
   clearMatrixTileRefreshTimer(iframe);
   iframe.src = 'about:blank';
-  if (remove) iframe.remove();
+  iframe.removeAttribute('src');
+  if (iframe.parentNode) iframe.parentNode.removeChild(iframe);
 }
 
 function disposeMatrixTile(tile, { remove = false } = {}) {
@@ -1152,8 +1153,11 @@ function resetMatrixForReinit() {
     disposeMatrixIframe(iframe, { remove: true });
   }
   disposeAllMatrixIframes({ remove: true });
-  matrixBody.innerHTML = '';
-  if (matrixOnlineFeedEl) matrixOnlineFeedEl.innerHTML = '';
+  return new Promise((resolve) => setTimeout(() => {
+    matrixBody.innerHTML = '';
+    if (matrixOnlineFeedEl) matrixOnlineFeedEl.innerHTML = '';
+    resolve();
+  }, 50));
 }
 
 async function replaceMatrixTileStream(tile, nextName) {
@@ -1178,7 +1182,7 @@ async function replaceMatrixTileStream(tile, nextName) {
   }
 
   lastLive = nextLive;
-  resetMatrixForReinit();
+  await resetMatrixForReinit();
   openMatrix();
 }
 
@@ -1431,7 +1435,7 @@ window.addEventListener('beforeunload', () => {
 });
 
 async function refreshMatrix() {
-  resetMatrixForReinit();
+  await resetMatrixForReinit();
   await retrieveAll();
   generateFromCache();
   openMatrix();


### PR DESCRIPTION
### Motivation

- Prevent Safari from retaining Twitch iframe/player internals which causes memory growth and eventual page freeze by ensuring iframes are fully detached and allowing time for GC before wiping the container. 
- Avoid teardown/rebuild races when replacing a single tile or performing a full matrix refresh by making reset operations asynchronous and awaited.

### Description

- Change `disposeMatrixIframe` to call `iframe.removeAttribute('src')` and unconditionally remove the iframe node via `iframe.parentNode.removeChild(iframe)` after blanking the `src`, so the node is fully detached from the DOM. 
- Change `resetMatrixForReinit` to return a `Promise` that waits `50ms` (via `setTimeout`) before clearing `matrixBody.innerHTML` and `matrixOnlineFeedEl.innerHTML`, giving Safari time to cleanup player internals. 
- Add `await resetMatrixForReinit()` in both `replaceMatrixTileStream` and `refreshMatrix` to ensure teardown completes before rebuilding the matrix. 
- No other grid, picker, pin/blacklist, or feed-scroll logic was modified.

### Testing

- Ran `git diff -- index.html` to verify the intended changes are present and the diff output matched expectations, which succeeded. 
- Applied the patch (`apply_patch`) and committed the change with `git commit -m "Fix Safari matrix iframe disposal and reinit timing"`, which succeeded. 
- Inspected updated file regions with `nl -ba index.html | sed -n '1000,1025p;1140,1192p;1428,1444p'` to confirm the edits were placed correctly, which succeeded.
- Created PR metadata using the `make_pr` helper, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11043f685883328b8b1879441b21cd)