### PR TITLE
Fix matrix tile picker listener leak via AbortController

### DIFF
--- a/index.html
+++ b/index.html
@@ -1196,6 +1196,8 @@ function openMatrixTilePicker(tile) {
   const candidates = getMatrixReplacementCandidates(currentName);
   if (!candidates.length) return;
 
+  const ac = new AbortController();
+
   const select = document.createElement('select');
   select.className = 'matrix-streamer-picker';
   const placeholder = document.createElement('option');
@@ -1211,12 +1213,19 @@ function openMatrixTilePicker(tile) {
   });
 
   select.addEventListener('change', async () => {
+    ac.abort();
     const nextName = select.value;
     if (!nextName) return;
     await replaceMatrixTileStream(tile, nextName);
     renderMatrixOnlineFeed();
-  });
-  select.addEventListener('blur', () => { setTimeout(() => select.remove(), 100); });
+  }, { signal: ac.signal });
+
+  select.addEventListener('blur', () => {
+    setTimeout(() => {
+      ac.abort();
+      select.remove();
+    }, 100);
+  }, { signal: ac.signal });
 
   tile.appendChild(select);
   select.focus();


### PR DESCRIPTION
### Motivation
- `openMatrixTilePicker` created per-picker `select` elements with `change` and `blur` handlers that closed over the tile/select, and Safari could retain those closures after DOM removal, causing memory retention and crash risk. 
- The intent is to ensure both listeners are cancelled together so stale closures no longer hold references after the picker is disposed.

### Description
- Add a per-picker `AbortController` and store it in `ac` inside `openMatrixTilePicker` to manage the picker lifecycle. 
- Attach the `change` and `blur` listeners with `{ signal: ac.signal }` so they are removed when `ac.abort()` is called. 
- Call `ac.abort()` on selection change and again before delayed `blur`-driven removal to ensure listeners are torn down before the element is removed. 

### Testing
- Ran static code validation (`git diff --check`) and it reported no issues. 
- Automated file inspection confirmed the `openMatrixTilePicker` block in `index.html` was replaced with the `AbortController`-backed implementation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1114974a748332b107c7489c911845)