### PR TITLE
Enforce low-quality Twitch streams and mute state for matrix players

### DIFF
--- a/index.html
+++ b/index.html
@@ -867,6 +867,9 @@ function setTwitchPlayerChannel(index, channelName) {
   if (!player) return;
   if (typeof player.setChannel === 'function') {
     player.setChannel(channelName);
+    setTimeout(() => {
+      try { player.setQuality('160p30'); } catch(e) { /* ignore */ }
+    }, 2000);
   } else {
     console.warn(`setChannel not available on player ${index}`);
   }
@@ -1206,11 +1209,15 @@ function openMatrix() {
         height: '100%',
         autoplay: true,
         muted: true,
+        volume: 0,
         controls: false,
         quality: '160p',
         parent: [STATIC_HOST]
       });
       matrixPlayers.set(index, player);
+      player.addEventListener(Twitch.Player.READY, () => {
+        try { player.setQuality('160p30'); } catch(e) { /* ignore if unavailable */ }
+      });
     });
 
     matrixInitialized = true;
@@ -1236,6 +1243,7 @@ function openMatrix() {
 
     /* Resume players that were paused on close */
     playAllMatrixPlayers();
+    matrixPlayers.forEach(p => { try { p.setMuted(false); } catch(e){} });
   }
 
   renderMatrixOnlineFeed();
@@ -1256,6 +1264,7 @@ function closeMatrix() {
 
   /* Pause all players to reduce background resource usage */
   pauseAllMatrixPlayers();
+  matrixPlayers.forEach(p => { try { p.setMuted(true); } catch(e){} });
 
   matrixBackdrop.style.display = 'none';
   document.body.style.overflow = '';

--- a/versions/twitchmatrixtwo.html
+++ b/versions/twitchmatrixtwo.html
@@ -867,6 +867,9 @@ function setTwitchPlayerChannel(index, channelName) {
   if (!player) return;
   if (typeof player.setChannel === 'function') {
     player.setChannel(channelName);
+    setTimeout(() => {
+      try { player.setQuality('160p30'); } catch(e) { /* ignore */ }
+    }, 2000);
   } else {
     console.warn(`setChannel not available on player ${index}`);
   }
@@ -1206,11 +1209,15 @@ function openMatrix() {
         height: '100%',
         autoplay: true,
         muted: true,
+        volume: 0,
         controls: false,
         quality: '160p',
         parent: [STATIC_HOST]
       });
       matrixPlayers.set(index, player);
+      player.addEventListener(Twitch.Player.READY, () => {
+        try { player.setQuality('160p30'); } catch(e) { /* ignore if unavailable */ }
+      });
     });
 
     matrixInitialized = true;
@@ -1236,6 +1243,7 @@ function openMatrix() {
 
     /* Resume players that were paused on close */
     playAllMatrixPlayers();
+    matrixPlayers.forEach(p => { try { p.setMuted(false); } catch(e){} });
   }
 
   renderMatrixOnlineFeed();
@@ -1256,6 +1264,7 @@ function closeMatrix() {
 
   /* Pause all players to reduce background resource usage */
   pauseAllMatrixPlayers();
+  matrixPlayers.forEach(p => { try { p.setMuted(true); } catch(e){} });
 
   matrixBackdrop.style.display = 'none';
   document.body.style.overflow = '';


### PR DESCRIPTION
### Motivation
- The Twitch embed `quality` constructor option is only a hint, so `setQuality()` must be called after the player is ready to reliably force the lowest decode tier. 
- `setChannel()` can reset quality on channel switches, so re-applying quality after channel changes prevents higher-tier decoding. 
- Muting players while the overlay is hidden reduces audio decode overhead, and setting `volume: 0` in addition to `muted: true` ensures silence across browser variants.

### Description
- Added `volume: 0` to the `Twitch.Player` constructor options so new players start fully silent. 
- Attached a `Twitch.Player.READY` listener after creating each player to call `player.setQuality('160p30')` inside a `try/catch`. 
- In `setTwitchPlayerChannel()` added a `setTimeout(..., 2000)` after `player.setChannel(...)` to call `player.setQuality('160p30')` again inside a `try/catch`. 
- On `closeMatrix()` muted all players after pausing them and on reopening (existing-player branch of `openMatrix()`) unmuted players after resuming playback. 
- Applied the same changes to both `index.html` and `versions/twitchmatrixtwo.html`.

### Testing
- Verified the file diffs to confirm the `volume`, READY listener, delayed quality re-apply, and mute/unmute calls were added to both target files and the diffs look correct. 
- Saved changes and published a pull request via the repository tooling (PR creation succeeded). 
- No automated unit tests exist for the player runtime behavior; behavior should be verified in a browser with the Twitch embed runtime to confirm quality and mute handling at runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13b12c6288833292e0dcd76c26f647)