### PR TITLE
Enable Twitch player controls and remove auto-pause/mute behavior in matrix view

### DIFF
--- a/index.html
+++ b/index.html
@@ -885,22 +885,6 @@ function updateTileBadge(index, channelName) {
   if (xbtn) setMatrixPinStateButtonStyle(xbtn, channelName);
 }
 
-function pauseAllMatrixPlayers() {
-  matrixPlayers.forEach((player) => {
-    if (player && typeof player.pause === 'function') {
-      try { player.pause(); } catch(e) { /* ignore */ }
-    }
-  });
-}
-
-function playAllMatrixPlayers() {
-  matrixPlayers.forEach((player) => {
-    if (player && typeof player.play === 'function') {
-      try { player.play(); } catch(e) { /* ignore */ }
-    }
-  });
-}
-
 /* --- Interval --- */
 function getRefreshMinutes() {
   const n = parseInt(document.getElementById("inputRefresh")?.value || "0", 10);
@@ -1210,7 +1194,7 @@ function openMatrix() {
         autoplay: true,
         muted: true,
         volume: 0,
-        controls: false,
+        controls: true,
         quality: '160p',
         parent: [STATIC_HOST]
       });
@@ -1242,8 +1226,6 @@ function openMatrix() {
     });
 
     /* Resume players that were paused on close */
-    playAllMatrixPlayers();
-    matrixPlayers.forEach(p => { try { p.setMuted(false); } catch(e){} });
   }
 
   renderMatrixOnlineFeed();
@@ -1261,10 +1243,6 @@ function closeMatrix() {
   stopMatrixRefreshInterval();
   matrixCountdownSeconds = 0;
   matrixRefreshCountdownEl.textContent = '';
-
-  /* Pause all players to reduce background resource usage */
-  pauseAllMatrixPlayers();
-  matrixPlayers.forEach(p => { try { p.setMuted(true); } catch(e){} });
 
   matrixBackdrop.style.display = 'none';
   document.body.style.overflow = '';

--- a/versions/twitchmatrixtwo.html
+++ b/versions/twitchmatrixtwo.html
@@ -885,22 +885,6 @@ function updateTileBadge(index, channelName) {
   if (xbtn) setMatrixPinStateButtonStyle(xbtn, channelName);
 }
 
-function pauseAllMatrixPlayers() {
-  matrixPlayers.forEach((player) => {
-    if (player && typeof player.pause === 'function') {
-      try { player.pause(); } catch(e) { /* ignore */ }
-    }
-  });
-}
-
-function playAllMatrixPlayers() {
-  matrixPlayers.forEach((player) => {
-    if (player && typeof player.play === 'function') {
-      try { player.play(); } catch(e) { /* ignore */ }
-    }
-  });
-}
-
 /* --- Interval --- */
 function getRefreshMinutes() {
   const n = parseInt(document.getElementById("inputRefresh")?.value || "0", 10);
@@ -1210,7 +1194,7 @@ function openMatrix() {
         autoplay: true,
         muted: true,
         volume: 0,
-        controls: false,
+        controls: true,
         quality: '160p',
         parent: [STATIC_HOST]
       });
@@ -1242,8 +1226,6 @@ function openMatrix() {
     });
 
     /* Resume players that were paused on close */
-    playAllMatrixPlayers();
-    matrixPlayers.forEach(p => { try { p.setMuted(false); } catch(e){} });
   }
 
   renderMatrixOnlineFeed();
@@ -1261,10 +1243,6 @@ function closeMatrix() {
   stopMatrixRefreshInterval();
   matrixCountdownSeconds = 0;
   matrixRefreshCountdownEl.textContent = '';
-
-  /* Pause all players to reduce background resource usage */
-  pauseAllMatrixPlayers();
-  matrixPlayers.forEach(p => { try { p.setMuted(true); } catch(e){} });
 
   matrixBackdrop.style.display = 'none';
   document.body.style.overflow = '';


### PR DESCRIPTION
### Motivation

- Expose the Twitch player controls in the matrix tiles to allow users to interact with individual players.  
- Stop implicitly pausing and muting players when the matrix is opened or closed to keep player state persistent and avoid unnecessary player control operations.

### Description

- Changed the Twitch player configuration to enable controls by setting `controls: true` when creating `Twitch.Player` instances in `index.html` and `versions/twitchmatrixtwo.html`.  
- Removed the `pauseAllMatrixPlayers` and `playAllMatrixPlayers` helper functions from both files.  
- Removed the code paths that automatically resumed players on matrix open (`playAllMatrixPlayers()` and unmuting calls) and that paused/muted players on matrix close.  
- Kept the existing behavior of reusing players via `setChannel` and updating tile badges without destroying player instances.

### Testing

- No automated tests were added or modified for this change.  
- No automated test suite was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13b382445c8332a6c0fc201d846bbd)