### PR TITLE
Use visibility/pointer-events to hide matrix overlay (preserve Safari playback)

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,9 @@
     .matrix-backdrop {
       position: fixed; inset: 0;
       background: rgba(0,0,0,.9);
-      display: none;
+      display: flex;
+      visibility: hidden;
+      pointer-events: none;
       align-items: stretch; justify-content: stretch;
       z-index: 10000;
     }
@@ -807,7 +809,7 @@ function initPersistence(){
   document.querySelectorAll('#inputBatch,#inputSize,#inputRefresh,#lim1,#lim2,#lim3,#lim4,#lim5,#lim6').forEach(el=>el.addEventListener("change", persist));
   [1,2,3,4,5,6].forEach(i=>document.getElementById("lim"+i).addEventListener("change", renderTierOnlineSnapshot));
   document.getElementById("inputRefresh").addEventListener("change", () => {
-    if (matrixBackdrop.style.display === 'flex') startMatrixRefreshInterval();
+    if (matrixBackdrop.style.visibility === 'visible') startMatrixRefreshInterval();
   });
   [1,2,3,4,5,6].forEach(i=>document.getElementById("rand"+i).addEventListener("change", persist));
 }
@@ -829,7 +831,7 @@ function closePreview() {
 }
 previewBackdrop.addEventListener('click', (e) => { if (e.target === previewBackdrop) closePreview(); });
 previewBackdrop.querySelector('.preview-close').addEventListener('click', closePreview);
-document.addEventListener('keydown', (e) => { if (e.key === 'Escape') { if (matrixBackdrop.style.display==='flex') closeMatrix(); else closePreview(); } });
+document.addEventListener('keydown', (e) => { if (e.key === 'Escape') { if (matrixBackdrop.style.visibility==='visible') closeMatrix(); else closePreview(); } });
 
 function makePreviewCard(name) {
   const r = resultsCache.get(name) || {};
@@ -1066,7 +1068,7 @@ matrixOnlineFeedEl?.addEventListener("click", async (e) => {
 
 /* --- Refresh displayed streams (timer path) --- */
 async function refreshDisplayedMatrixStreams() {
-  if (matrixBackdrop.style.display !== 'flex') return;
+  if (matrixBackdrop.style.visibility !== 'visible') return;
   const displayed = getDisplayedMatrixStreams();
   if (!displayed.length) return;
   const fetched = await fetchBatch(displayed);
@@ -1150,7 +1152,8 @@ function openMatrix() {
     return;
   }
 
-  matrixBackdrop.style.display = 'flex';
+  matrixBackdrop.style.visibility = 'visible';
+  matrixBackdrop.style.pointerEvents = '';
   document.body.style.overflow = 'hidden';
 
   if (!matrixInitialized) {
@@ -1244,7 +1247,8 @@ function closeMatrix() {
   matrixCountdownSeconds = 0;
   matrixRefreshCountdownEl.textContent = '';
 
-  matrixBackdrop.style.display = 'none';
+  matrixBackdrop.style.visibility = 'hidden';
+  matrixBackdrop.style.pointerEvents = 'none';
   document.body.style.overflow = '';
 
   if (matrixResizeHandler) {

--- a/versions/twitchmatrixtwo.html
+++ b/versions/twitchmatrixtwo.html
@@ -130,7 +130,9 @@
     .matrix-backdrop {
       position: fixed; inset: 0;
       background: rgba(0,0,0,.9);
-      display: none;
+      display: flex;
+      visibility: hidden;
+      pointer-events: none;
       align-items: stretch; justify-content: stretch;
       z-index: 10000;
     }
@@ -807,7 +809,7 @@ function initPersistence(){
   document.querySelectorAll('#inputBatch,#inputSize,#inputRefresh,#lim1,#lim2,#lim3,#lim4,#lim5,#lim6').forEach(el=>el.addEventListener("change", persist));
   [1,2,3,4,5,6].forEach(i=>document.getElementById("lim"+i).addEventListener("change", renderTierOnlineSnapshot));
   document.getElementById("inputRefresh").addEventListener("change", () => {
-    if (matrixBackdrop.style.display === 'flex') startMatrixRefreshInterval();
+    if (matrixBackdrop.style.visibility === 'visible') startMatrixRefreshInterval();
   });
   [1,2,3,4,5,6].forEach(i=>document.getElementById("rand"+i).addEventListener("change", persist));
 }
@@ -829,7 +831,7 @@ function closePreview() {
 }
 previewBackdrop.addEventListener('click', (e) => { if (e.target === previewBackdrop) closePreview(); });
 previewBackdrop.querySelector('.preview-close').addEventListener('click', closePreview);
-document.addEventListener('keydown', (e) => { if (e.key === 'Escape') { if (matrixBackdrop.style.display==='flex') closeMatrix(); else closePreview(); } });
+document.addEventListener('keydown', (e) => { if (e.key === 'Escape') { if (matrixBackdrop.style.visibility==='visible') closeMatrix(); else closePreview(); } });
 
 function makePreviewCard(name) {
   const r = resultsCache.get(name) || {};
@@ -1066,7 +1068,7 @@ matrixOnlineFeedEl?.addEventListener("click", async (e) => {
 
 /* --- Refresh displayed streams (timer path) --- */
 async function refreshDisplayedMatrixStreams() {
-  if (matrixBackdrop.style.display !== 'flex') return;
+  if (matrixBackdrop.style.visibility !== 'visible') return;
   const displayed = getDisplayedMatrixStreams();
   if (!displayed.length) return;
   const fetched = await fetchBatch(displayed);
@@ -1150,7 +1152,8 @@ function openMatrix() {
     return;
   }
 
-  matrixBackdrop.style.display = 'flex';
+  matrixBackdrop.style.visibility = 'visible';
+  matrixBackdrop.style.pointerEvents = '';
   document.body.style.overflow = 'hidden';
 
   if (!matrixInitialized) {
@@ -1244,7 +1247,8 @@ function closeMatrix() {
   matrixCountdownSeconds = 0;
   matrixRefreshCountdownEl.textContent = '';
 
-  matrixBackdrop.style.display = 'none';
+  matrixBackdrop.style.visibility = 'hidden';
+  matrixBackdrop.style.pointerEvents = 'none';
   document.body.style.overflow = '';
 
   if (matrixResizeHandler) {


### PR DESCRIPTION
### Motivation
- Safari pauses embedded video when an element is removed from the render/layout tree via `display: none`, which breaks autoplay/resume behavior for persistent Twitch players. 
- The overlay should be hidden from view and interaction without unmounting its DOM or destroying player instances.

### Description
- Changed `.matrix-backdrop` CSS to keep `display: flex` and default to `visibility: hidden` plus `pointer-events: none` so the element stays mounted but non-interactive. 
- Replaced checks against `matrixBackdrop.style.display === 'flex'` with `matrixBackdrop.style.visibility === 'visible'` in refresh, Escape-key handling, and timer guards. 
- Updated `openMatrix()` to set `matrixBackdrop.style.visibility = 'visible'` and `matrixBackdrop.style.pointerEvents = ''` so the overlay becomes interactive without re-inserting it. 
- Updated `closeMatrix()` to set `matrixBackdrop.style.visibility = 'hidden'` and `matrixBackdrop.style.pointerEvents = 'none'` so the overlay is hidden but players remain mounted.

### Testing
- Verified both target files (`index.html` and `versions/twitchmatrixtwo.html`) are present with `rg --files | rg 'index|twitchmatrixtwo'` and the expected patterns no longer reference `display: none` for the matrix backdrop. 
- Ran scoped `rg -n` searches to confirm all `style.display` checks for the matrix were switched to `style.visibility` and to locate the updated CSS rule. 
- Inspected the modified regions with `sed`/`nl` to validate the `visibility`/`pointer-events` changes were applied in the open/close and refresh logic. 
- Generated PR metadata to summarize the change (files updated: `index.html`, `versions/twitchmatrixtwo.html`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14631323948332bbedcbbcec13649f)