### PR TITLE
Revert visibility-toggle change for matrix overlay and restore previous display handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,9 +130,7 @@
     .matrix-backdrop {
       position: fixed; inset: 0;
       background: rgba(0,0,0,.9);
-      display: flex;
-      visibility: hidden;
-      pointer-events: none;
+      display: none;
       align-items: stretch; justify-content: stretch;
       z-index: 10000;
     }
@@ -809,7 +807,7 @@ function initPersistence(){
   document.querySelectorAll('#inputBatch,#inputSize,#inputRefresh,#lim1,#lim2,#lim3,#lim4,#lim5,#lim6').forEach(el=>el.addEventListener("change", persist));
   [1,2,3,4,5,6].forEach(i=>document.getElementById("lim"+i).addEventListener("change", renderTierOnlineSnapshot));
   document.getElementById("inputRefresh").addEventListener("change", () => {
-    if (matrixBackdrop.style.visibility === 'visible') startMatrixRefreshInterval();
+    if (matrixBackdrop.style.display === 'flex') startMatrixRefreshInterval();
   });
   [1,2,3,4,5,6].forEach(i=>document.getElementById("rand"+i).addEventListener("change", persist));
 }
@@ -831,7 +829,7 @@ function closePreview() {
 }
 previewBackdrop.addEventListener('click', (e) => { if (e.target === previewBackdrop) closePreview(); });
 previewBackdrop.querySelector('.preview-close').addEventListener('click', closePreview);
-document.addEventListener('keydown', (e) => { if (e.key === 'Escape') { if (matrixBackdrop.style.visibility==='visible') closeMatrix(); else closePreview(); } });
+document.addEventListener('keydown', (e) => { if (e.key === 'Escape') { if (matrixBackdrop.style.display==='flex') closeMatrix(); else closePreview(); } });
 
 function makePreviewCard(name) {
   const r = resultsCache.get(name) || {};
@@ -1068,7 +1066,7 @@ matrixOnlineFeedEl?.addEventListener("click", async (e) => {
 
 /* --- Refresh displayed streams (timer path) --- */
 async function refreshDisplayedMatrixStreams() {
-  if (matrixBackdrop.style.visibility !== 'visible') return;
+  if (matrixBackdrop.style.display !== 'flex') return;
   const displayed = getDisplayedMatrixStreams();
   if (!displayed.length) return;
   const fetched = await fetchBatch(displayed);
@@ -1152,8 +1150,7 @@ function openMatrix() {
     return;
   }
 
-  matrixBackdrop.style.visibility = 'visible';
-  matrixBackdrop.style.pointerEvents = '';
+  matrixBackdrop.style.display = 'flex';
   document.body.style.overflow = 'hidden';
 
   if (!matrixInitialized) {
@@ -1247,8 +1244,7 @@ function closeMatrix() {
   matrixCountdownSeconds = 0;
   matrixRefreshCountdownEl.textContent = '';
 
-  matrixBackdrop.style.visibility = 'hidden';
-  matrixBackdrop.style.pointerEvents = 'none';
+  matrixBackdrop.style.display = 'none';
   document.body.style.overflow = '';
 
   if (matrixResizeHandler) {

--- a/versions/twitchmatrixtwo.html
+++ b/versions/twitchmatrixtwo.html
@@ -130,9 +130,7 @@
     .matrix-backdrop {
       position: fixed; inset: 0;
       background: rgba(0,0,0,.9);
-      display: flex;
-      visibility: hidden;
-      pointer-events: none;
+      display: none;
       align-items: stretch; justify-content: stretch;
       z-index: 10000;
     }
@@ -809,7 +807,7 @@ function initPersistence(){
   document.querySelectorAll('#inputBatch,#inputSize,#inputRefresh,#lim1,#lim2,#lim3,#lim4,#lim5,#lim6').forEach(el=>el.addEventListener("change", persist));
   [1,2,3,4,5,6].forEach(i=>document.getElementById("lim"+i).addEventListener("change", renderTierOnlineSnapshot));
   document.getElementById("inputRefresh").addEventListener("change", () => {
-    if (matrixBackdrop.style.visibility === 'visible') startMatrixRefreshInterval();
+    if (matrixBackdrop.style.display === 'flex') startMatrixRefreshInterval();
   });
   [1,2,3,4,5,6].forEach(i=>document.getElementById("rand"+i).addEventListener("change", persist));
 }
@@ -831,7 +829,7 @@ function closePreview() {
 }
 previewBackdrop.addEventListener('click', (e) => { if (e.target === previewBackdrop) closePreview(); });
 previewBackdrop.querySelector('.preview-close').addEventListener('click', closePreview);
-document.addEventListener('keydown', (e) => { if (e.key === 'Escape') { if (matrixBackdrop.style.visibility==='visible') closeMatrix(); else closePreview(); } });
+document.addEventListener('keydown', (e) => { if (e.key === 'Escape') { if (matrixBackdrop.style.display==='flex') closeMatrix(); else closePreview(); } });
 
 function makePreviewCard(name) {
   const r = resultsCache.get(name) || {};
@@ -1068,7 +1066,7 @@ matrixOnlineFeedEl?.addEventListener("click", async (e) => {
 
 /* --- Refresh displayed streams (timer path) --- */
 async function refreshDisplayedMatrixStreams() {
-  if (matrixBackdrop.style.visibility !== 'visible') return;
+  if (matrixBackdrop.style.display !== 'flex') return;
   const displayed = getDisplayedMatrixStreams();
   if (!displayed.length) return;
   const fetched = await fetchBatch(displayed);
@@ -1152,8 +1150,7 @@ function openMatrix() {
     return;
   }
 
-  matrixBackdrop.style.visibility = 'visible';
-  matrixBackdrop.style.pointerEvents = '';
+  matrixBackdrop.style.display = 'flex';
   document.body.style.overflow = 'hidden';
 
   if (!matrixInitialized) {
@@ -1247,8 +1244,7 @@ function closeMatrix() {
   matrixCountdownSeconds = 0;
   matrixRefreshCountdownEl.textContent = '';
 
-  matrixBackdrop.style.visibility = 'hidden';
-  matrixBackdrop.style.pointerEvents = 'none';
+  matrixBackdrop.style.display = 'none';
   document.body.style.overflow = '';
 
   if (matrixResizeHandler) {


### PR DESCRIPTION
### Motivation
- Restore the prior matrix overlay lifecycle because the visibility-toggle approach interfered with playback on some browsers and altered expected hide/show behavior. 
- Ensure both HTML entry points remain consistent in how the overlay is shown and hidden.

### Description
- Replaced the `.matrix-backdrop` initial CSS from using `visibility`/`pointer-events` to using `display: none` and use `display: flex` when shown. 
- Updated runtime checks and handlers to test `matrixBackdrop.style.display === 'flex'` instead of `matrixBackdrop.style.visibility === 'visible'`, and changed `openMatrix()`/`closeMatrix()` to set `style.display` accordingly. 
- Applied the same changes to `versions/twitchmatrixtwo.html` so both entry points behave identically.

### Testing
- No automated test suite was run; this is a revert-only UI/behavior change. 
- PR metadata was created for review and the revert was applied cleanly in the working tree.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1467be56d483329bf17f4d1393e67d)