### PR TITLE
Introduce MATRIX_RESOLUTION (360p) and use it for matrix player quality

### DIFF
--- a/index.html
+++ b/index.html
@@ -434,6 +434,8 @@ let sessionBlacklist = new Set();
 const matrixPlayers = new Map();
 const matrixTiles = new Map();
 let matrixInitialized = false;
+const MATRIX_RESOLUTION = '360p';
+const MATRIX_RESOLUTION_FPS = `${MATRIX_RESOLUTION}30`;
 
 /* ---------- Persistence ---------- */
 const LS_KEY = "twitchcategories_settings_v2";
@@ -868,7 +870,7 @@ function setTwitchPlayerChannel(index, channelName) {
   if (typeof player.setChannel === 'function') {
     player.setChannel(channelName);
     setTimeout(() => {
-      try { player.setQuality('160p30'); } catch(e) { /* ignore */ }
+      try { player.setQuality(MATRIX_RESOLUTION_FPS); } catch(e) { /* ignore */ }
     }, 2000);
   } else {
     console.warn(`setChannel not available on player ${index}`);
@@ -1195,12 +1197,12 @@ function openMatrix() {
         muted: true,
         volume: 0,
         controls: true,
-        quality: '160p',
+        quality: MATRIX_RESOLUTION,
         parent: [STATIC_HOST]
       });
       matrixPlayers.set(index, player);
       player.addEventListener(Twitch.Player.READY, () => {
-        try { player.setQuality('160p30'); } catch(e) { /* ignore if unavailable */ }
+        try { player.setQuality(MATRIX_RESOLUTION_FPS); } catch(e) { /* ignore if unavailable */ }
       });
     });
 

--- a/versions/twitchmatrixtwo.html
+++ b/versions/twitchmatrixtwo.html
@@ -434,6 +434,8 @@ let sessionBlacklist = new Set();
 const matrixPlayers = new Map();
 const matrixTiles = new Map();
 let matrixInitialized = false;
+const MATRIX_RESOLUTION = '360p';
+const MATRIX_RESOLUTION_FPS = `${MATRIX_RESOLUTION}30`;
 
 /* ---------- Persistence ---------- */
 const LS_KEY = "twitchcategories_settings_v2";
@@ -868,7 +870,7 @@ function setTwitchPlayerChannel(index, channelName) {
   if (typeof player.setChannel === 'function') {
     player.setChannel(channelName);
     setTimeout(() => {
-      try { player.setQuality('160p30'); } catch(e) { /* ignore */ }
+      try { player.setQuality(MATRIX_RESOLUTION_FPS); } catch(e) { /* ignore */ }
     }, 2000);
   } else {
     console.warn(`setChannel not available on player ${index}`);
@@ -1195,12 +1197,12 @@ function openMatrix() {
         muted: true,
         volume: 0,
         controls: true,
-        quality: '160p',
+        quality: MATRIX_RESOLUTION,
         parent: [STATIC_HOST]
       });
       matrixPlayers.set(index, player);
       player.addEventListener(Twitch.Player.READY, () => {
-        try { player.setQuality('160p30'); } catch(e) { /* ignore if unavailable */ }
+        try { player.setQuality(MATRIX_RESOLUTION_FPS); } catch(e) { /* ignore if unavailable */ }
       });
     });
 


### PR DESCRIPTION
### Motivation
- Centralize the embedded matrix player resolution so it can be changed in one place instead of scattered hardcoded values. 
- Default the matrix resolution to `360p` to reduce GPU/memory usage for multi-player matrices. 
- Ensure both the main page and the `twitchmatrixtwo` variant behave consistently.

### Description
- Added a shared `MATRIX_RESOLUTION` constant set to `'360p'` and a derived `MATRIX_RESOLUTION_FPS` constant in both `index.html` and `versions/twitchmatrixtwo.html` placed with the matrix/player state. 
- Replaced hardcoded initial player config `quality: '160p'` with `quality: MATRIX_RESOLUTION` in the Twitch player options. 
- Replaced `player.setQuality('160p30')` calls with `player.setQuality(MATRIX_RESOLUTION_FPS)` for both initial readiness and after `setChannel` updates.

### Testing
- Searched the modified files for remaining hardcoded values using `rg -n "MATRIX_RESOLUTION|160p|setQuality\(|quality:" index.html versions/twitchmatrixtwo.html` and confirmed references were updated. 
- Performed a broader search `rg -n "setQuality|quality|player|new Twitch\.Player|embed|source|360" index.html versions/twitchmatrixtwo.html` to validate no unintended occurrences remained. 
- Inspected the relevant line ranges with `nl`/`sed` to verify the constants and replacements appear in the expected locations and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1469feb8d883328de746c9fbc2f3a0)