### PR TITLE
Set player quality on PLAYING event instead of timeout

### DIFF
--- a/index.html
+++ b/index.html
@@ -861,6 +861,15 @@ let matrixResizeHandler = null;
 
 /* --- Player helpers --- */
 
+function applyMatrixQualityOnNextPlaying(player) {
+  if (!player || typeof player.addEventListener !== 'function' || typeof player.removeEventListener !== 'function') return;
+  const applyQuality = () => {
+    player.removeEventListener(Twitch.Player.PLAYING, applyQuality);
+    try { player.setQuality(MATRIX_RESOLUTION_FPS); } catch(e) { /* ignore */ }
+  };
+  player.addEventListener(Twitch.Player.PLAYING, applyQuality);
+}
+
 function setTwitchPlayerChannel(index, channelName) {
   /* The ONLY correct way to change a stream without destroying the player.
      Twitch.Player.setChannel() transitions the existing decoder context
@@ -869,9 +878,7 @@ function setTwitchPlayerChannel(index, channelName) {
   if (!player) return;
   if (typeof player.setChannel === 'function') {
     player.setChannel(channelName);
-    setTimeout(() => {
-      try { player.setQuality(MATRIX_RESOLUTION_FPS); } catch(e) { /* ignore */ }
-    }, 2000);
+    applyMatrixQualityOnNextPlaying(player);
   } else {
     console.warn(`setChannel not available on player ${index}`);
   }

--- a/versions/twitchmatrixtwo.html
+++ b/versions/twitchmatrixtwo.html
@@ -861,6 +861,15 @@ let matrixResizeHandler = null;
 
 /* --- Player helpers --- */
 
+function applyMatrixQualityOnNextPlaying(player) {
+  if (!player || typeof player.addEventListener !== 'function' || typeof player.removeEventListener !== 'function') return;
+  const applyQuality = () => {
+    player.removeEventListener(Twitch.Player.PLAYING, applyQuality);
+    try { player.setQuality(MATRIX_RESOLUTION_FPS); } catch(e) { /* ignore */ }
+  };
+  player.addEventListener(Twitch.Player.PLAYING, applyQuality);
+}
+
 function setTwitchPlayerChannel(index, channelName) {
   /* The ONLY correct way to change a stream without destroying the player.
      Twitch.Player.setChannel() transitions the existing decoder context
@@ -869,9 +878,7 @@ function setTwitchPlayerChannel(index, channelName) {
   if (!player) return;
   if (typeof player.setChannel === 'function') {
     player.setChannel(channelName);
-    setTimeout(() => {
-      try { player.setQuality(MATRIX_RESOLUTION_FPS); } catch(e) { /* ignore */ }
-    }, 2000);
+    applyMatrixQualityOnNextPlaying(player);
   } else {
     console.warn(`setChannel not available on player ${index}`);
   }


### PR DESCRIPTION
### Motivation
- Avoid flaky `setQuality` calls scheduled via `setTimeout` which can miss the right player state and be unreliable when switching channels.
- Ensure quality is applied exactly when a `Twitch.Player` starts playing to reduce race conditions and unnecessary retries.

### Description
- Added helper `applyMatrixQualityOnNextPlaying(player)` that attaches a one-time `Twitch.Player.PLAYING` listener and calls `player.setQuality(MATRIX_RESOLUTION_FPS)` inside a try/catch.
- Replaced the previous `setTimeout(...setQuality...)` approach in `setTwitchPlayerChannel` with a call to `applyMatrixQualityOnNextPlaying(player)` to apply quality when playback actually begins.
- Added guards to ensure the helper only attaches listeners when `player` exposes `addEventListener`/`removeEventListener` to avoid runtime errors.
- Changes applied to `index.html` and `versions/twitchmatrixtwo.html`.

### Testing
- No automated tests were added or run for this UI change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1485d129c48332840cbf5f8b660522)