### PR TITLE
Keep matrix 360p PLAYING listener active and clean it up on teardown

### DIFF
--- a/index.html
+++ b/index.html
@@ -858,16 +858,33 @@ let matrixRefreshIntervalId = null;
 let matrixRefreshInProgress = false;
 let matrixCountdownSeconds = 0;
 let matrixResizeHandler = null;
+const matrixPlayingListeners = new Map();
 
 /* --- Player helpers --- */
 
 function applyMatrixQualityOnNextPlaying(player) {
-  if (!player || typeof player.addEventListener !== 'function' || typeof player.removeEventListener !== 'function') return;
+  if (!player || typeof player.addEventListener !== 'function') return;
+  if (matrixPlayingListeners.has(player)) return;
   const applyQuality = () => {
-    player.removeEventListener(Twitch.Player.PLAYING, applyQuality);
     try { player.setQuality(MATRIX_RESOLUTION_FPS); } catch(e) { /* ignore */ }
   };
+  matrixPlayingListeners.set(player, applyQuality);
   player.addEventListener(Twitch.Player.PLAYING, applyQuality);
+}
+
+function removeMatrixQualityPlayingListener(player) {
+  const applyQuality = matrixPlayingListeners.get(player);
+  if (!applyQuality) return;
+  if (typeof player.removeEventListener === 'function') {
+    player.removeEventListener(Twitch.Player.PLAYING, applyQuality);
+  }
+  matrixPlayingListeners.delete(player);
+}
+
+function teardownMatrixPlayers() {
+  matrixPlayers.forEach((player) => {
+    removeMatrixQualityPlayingListener(player);
+  });
 }
 
 function setTwitchPlayerChannel(index, channelName) {
@@ -1211,6 +1228,7 @@ function openMatrix() {
       player.addEventListener(Twitch.Player.READY, () => {
         try { player.setQuality(MATRIX_RESOLUTION_FPS); } catch(e) { /* ignore if unavailable */ }
       });
+      applyMatrixQualityOnNextPlaying(player);
     });
 
     matrixInitialized = true;
@@ -1261,6 +1279,8 @@ function closeMatrix() {
     matrixResizeHandler = null;
   }
 }
+
+window.addEventListener('beforeunload', teardownMatrixPlayers);
 
 /* --- refreshMatrix — retrieve + generate + update via setChannel --- */
 async function refreshMatrix() {

--- a/versions/twitchmatrixtwo.html
+++ b/versions/twitchmatrixtwo.html
@@ -858,16 +858,33 @@ let matrixRefreshIntervalId = null;
 let matrixRefreshInProgress = false;
 let matrixCountdownSeconds = 0;
 let matrixResizeHandler = null;
+const matrixPlayingListeners = new Map();
 
 /* --- Player helpers --- */
 
 function applyMatrixQualityOnNextPlaying(player) {
-  if (!player || typeof player.addEventListener !== 'function' || typeof player.removeEventListener !== 'function') return;
+  if (!player || typeof player.addEventListener !== 'function') return;
+  if (matrixPlayingListeners.has(player)) return;
   const applyQuality = () => {
-    player.removeEventListener(Twitch.Player.PLAYING, applyQuality);
     try { player.setQuality(MATRIX_RESOLUTION_FPS); } catch(e) { /* ignore */ }
   };
+  matrixPlayingListeners.set(player, applyQuality);
   player.addEventListener(Twitch.Player.PLAYING, applyQuality);
+}
+
+function removeMatrixQualityPlayingListener(player) {
+  const applyQuality = matrixPlayingListeners.get(player);
+  if (!applyQuality) return;
+  if (typeof player.removeEventListener === 'function') {
+    player.removeEventListener(Twitch.Player.PLAYING, applyQuality);
+  }
+  matrixPlayingListeners.delete(player);
+}
+
+function teardownMatrixPlayers() {
+  matrixPlayers.forEach((player) => {
+    removeMatrixQualityPlayingListener(player);
+  });
 }
 
 function setTwitchPlayerChannel(index, channelName) {
@@ -1211,6 +1228,7 @@ function openMatrix() {
       player.addEventListener(Twitch.Player.READY, () => {
         try { player.setQuality(MATRIX_RESOLUTION_FPS); } catch(e) { /* ignore if unavailable */ }
       });
+      applyMatrixQualityOnNextPlaying(player);
     });
 
     matrixInitialized = true;
@@ -1261,6 +1279,8 @@ function closeMatrix() {
     matrixResizeHandler = null;
   }
 }
+
+window.addEventListener('beforeunload', teardownMatrixPlayers);
 
 /* --- refreshMatrix — retrieve + generate + update via setChannel --- */
 async function refreshMatrix() {


### PR DESCRIPTION
### Motivation
- Matrix Twitch players are persistent and reused, so the quality listener must remain attached to re-apply 360p when playback restarts or after channel switches.
- The previous one-shot removal meant subsequent play events could miss forcing the desired resolution on long-lived players.

### Description
- Add a `matrixPlayingListeners` Map to track per-player `PLAYING` handlers and avoid duplicate registrations.
- Change `applyMatrixQualityOnNextPlaying` to install a persistent, deduped listener that calls `player.setQuality(MATRIX_RESOLUTION_FPS)` and record it in the map.
- Add `removeMatrixQualityPlayingListener(player)` and `teardownMatrixPlayers()` helpers to remove saved listeners, and call `applyMatrixQualityOnNextPlaying` when creating each player.
- Wire `teardownMatrixPlayers()` to the `beforeunload` event and apply identical edits to both `index.html` and `versions/twitchmatrixtwo.html`.

### Testing
- Applied the patch to both `index.html` and `versions/twitchmatrixtwo.html` successfully as reported by the patch tool.
- Ran repository checks using `git diff --check` which produced no issues.
- Verified the working tree with `git status --short` and inspected the updated regions to confirm the new functions and `beforeunload` hook were present.
- Confirmed the new listener is installed during initial player creation by inspecting the updated file snippets for the `applyMatrixQualityOnNextPlaying` call.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a149e9afba48332abfca982f8eb9847)