### PR TITLE
Revert persistent matrix PLAYING listener change

### DIFF
--- a/index.html
+++ b/index.html
@@ -858,33 +858,16 @@ let matrixRefreshIntervalId = null;
 let matrixRefreshInProgress = false;
 let matrixCountdownSeconds = 0;
 let matrixResizeHandler = null;
-const matrixPlayingListeners = new Map();
 
 /* --- Player helpers --- */
 
 function applyMatrixQualityOnNextPlaying(player) {
-  if (!player || typeof player.addEventListener !== 'function') return;
-  if (matrixPlayingListeners.has(player)) return;
+  if (!player || typeof player.addEventListener !== 'function' || typeof player.removeEventListener !== 'function') return;
   const applyQuality = () => {
+    player.removeEventListener(Twitch.Player.PLAYING, applyQuality);
     try { player.setQuality(MATRIX_RESOLUTION_FPS); } catch(e) { /* ignore */ }
   };
-  matrixPlayingListeners.set(player, applyQuality);
   player.addEventListener(Twitch.Player.PLAYING, applyQuality);
-}
-
-function removeMatrixQualityPlayingListener(player) {
-  const applyQuality = matrixPlayingListeners.get(player);
-  if (!applyQuality) return;
-  if (typeof player.removeEventListener === 'function') {
-    player.removeEventListener(Twitch.Player.PLAYING, applyQuality);
-  }
-  matrixPlayingListeners.delete(player);
-}
-
-function teardownMatrixPlayers() {
-  matrixPlayers.forEach((player) => {
-    removeMatrixQualityPlayingListener(player);
-  });
 }
 
 function setTwitchPlayerChannel(index, channelName) {
@@ -1228,7 +1211,6 @@ function openMatrix() {
       player.addEventListener(Twitch.Player.READY, () => {
         try { player.setQuality(MATRIX_RESOLUTION_FPS); } catch(e) { /* ignore if unavailable */ }
       });
-      applyMatrixQualityOnNextPlaying(player);
     });
 
     matrixInitialized = true;
@@ -1279,8 +1261,6 @@ function closeMatrix() {
     matrixResizeHandler = null;
   }
 }
-
-window.addEventListener('beforeunload', teardownMatrixPlayers);
 
 /* --- refreshMatrix — retrieve + generate + update via setChannel --- */
 async function refreshMatrix() {

--- a/versions/twitchmatrixtwo.html
+++ b/versions/twitchmatrixtwo.html
@@ -858,33 +858,16 @@ let matrixRefreshIntervalId = null;
 let matrixRefreshInProgress = false;
 let matrixCountdownSeconds = 0;
 let matrixResizeHandler = null;
-const matrixPlayingListeners = new Map();
 
 /* --- Player helpers --- */
 
 function applyMatrixQualityOnNextPlaying(player) {
-  if (!player || typeof player.addEventListener !== 'function') return;
-  if (matrixPlayingListeners.has(player)) return;
+  if (!player || typeof player.addEventListener !== 'function' || typeof player.removeEventListener !== 'function') return;
   const applyQuality = () => {
+    player.removeEventListener(Twitch.Player.PLAYING, applyQuality);
     try { player.setQuality(MATRIX_RESOLUTION_FPS); } catch(e) { /* ignore */ }
   };
-  matrixPlayingListeners.set(player, applyQuality);
   player.addEventListener(Twitch.Player.PLAYING, applyQuality);
-}
-
-function removeMatrixQualityPlayingListener(player) {
-  const applyQuality = matrixPlayingListeners.get(player);
-  if (!applyQuality) return;
-  if (typeof player.removeEventListener === 'function') {
-    player.removeEventListener(Twitch.Player.PLAYING, applyQuality);
-  }
-  matrixPlayingListeners.delete(player);
-}
-
-function teardownMatrixPlayers() {
-  matrixPlayers.forEach((player) => {
-    removeMatrixQualityPlayingListener(player);
-  });
 }
 
 function setTwitchPlayerChannel(index, channelName) {
@@ -1228,7 +1211,6 @@ function openMatrix() {
       player.addEventListener(Twitch.Player.READY, () => {
         try { player.setQuality(MATRIX_RESOLUTION_FPS); } catch(e) { /* ignore if unavailable */ }
       });
-      applyMatrixQualityOnNextPlaying(player);
     });
 
     matrixInitialized = true;
@@ -1279,8 +1261,6 @@ function closeMatrix() {
     matrixResizeHandler = null;
   }
 }
-
-window.addEventListener('beforeunload', teardownMatrixPlayers);
 
 /* --- refreshMatrix — retrieve + generate + update via setChannel --- */
 async function refreshMatrix() {


### PR DESCRIPTION
### Motivation
- Restore previous one-shot `PLAYING` listener behavior for matrix players because persistent listeners were causing repeated quality forcing during playback transitions. 
- Prevent repeated `setQuality(...)` calls that can keep streams in a rebuffer/restart loop and manifest as an endless spinner. 

### Description
- Reverted the change that introduced a `Map` of persistent `PLAYING` listeners and the accompanying `removeMatrixQualityPlayingListener` / `teardownMatrixPlayers` helpers. 
- Restored `applyMatrixQualityOnNextPlaying(player)` to attach a one-shot listener that calls `player.removeEventListener(...)` after the first `PLAYING` event. 
- Removed the call that attached persistent listeners during initial player creation and removed the `beforeunload` teardown wiring so listeners are not retained for the lifetime of the page. 
- Changes are applied to `index.html` and `versions/twitchmatrixtwo.html` to revert the persistent-listener lifecycle back to the prior behavior. 

### Testing
- Ran `git status` and `git log` to confirm repo state and that the revert was applied successfully (commands completed successfully). 
- Inspected the patch with `git show` and verified that the persistent-listener code and `beforeunload` teardown were removed (inspection succeeded). 
- Displayed relevant file sections with `nl`/`sed` to confirm `applyMatrixQualityOnNextPlaying` now uses a one-shot removal and that persistent-listener bookkeeping is gone (inspection succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14a1e966288332bf3055d5115124df)