### PR TITLE
Fix orphaned PLAYING quality listeners per player slot

### DIFF
--- a/index.html
+++ b/index.html
@@ -858,15 +858,22 @@ let matrixRefreshIntervalId = null;
 let matrixRefreshInProgress = false;
 let matrixCountdownSeconds = 0;
 let matrixResizeHandler = null;
+const qualityListeners = new Map();
 
 /* --- Player helpers --- */
 
-function applyMatrixQualityOnNextPlaying(player) {
+function applyMatrixQualityOnNextPlaying(index, player) {
   if (!player || typeof player.addEventListener !== 'function' || typeof player.removeEventListener !== 'function') return;
+  const existingListener = qualityListeners.get(index);
+  if (existingListener) {
+    player.removeEventListener(Twitch.Player.PLAYING, existingListener);
+  }
   const applyQuality = () => {
     player.removeEventListener(Twitch.Player.PLAYING, applyQuality);
+    qualityListeners.delete(index);
     try { player.setQuality(MATRIX_RESOLUTION_FPS); } catch(e) { /* ignore */ }
   };
+  qualityListeners.set(index, applyQuality);
   player.addEventListener(Twitch.Player.PLAYING, applyQuality);
 }
 
@@ -878,7 +885,7 @@ function setTwitchPlayerChannel(index, channelName) {
   if (!player) return;
   if (typeof player.setChannel === 'function') {
     player.setChannel(channelName);
-    applyMatrixQualityOnNextPlaying(player);
+    applyMatrixQualityOnNextPlaying(index, player);
   } else {
     console.warn(`setChannel not available on player ${index}`);
   }


### PR DESCRIPTION
### Motivation
- Prevent accumulation of orphaned `Twitch.Player.PLAYING` one-shot listeners when swapping channels on persistent players, which caused a memory/listener leak for slots whose streams never emitted `PLAYING`.

### Description
- Add `qualityListeners = new Map()` keyed by matrix slot index to track the pending one-shot listener for each slot.
- Change `applyMatrixQualityOnNextPlaying` signature to accept `(index, player)` and remove any previously tracked listener for that slot before adding a new one.
- When the `PLAYING` listener runs it self-removes, deletes the map entry for the slot, and calls `player.setQuality(...)` as before.
- Update `setTwitchPlayerChannel` call site to pass the slot `index` into `applyMatrixQualityOnNextPlaying` without altering other logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17e5bfac508332851a0773449eb71a)