### PR TITLE
Revert fix for orphaned PLAYING quality listeners (PR #73)

### DIFF
--- a/index.html
+++ b/index.html
@@ -858,22 +858,15 @@ let matrixRefreshIntervalId = null;
 let matrixRefreshInProgress = false;
 let matrixCountdownSeconds = 0;
 let matrixResizeHandler = null;
-const qualityListeners = new Map();
 
 /* --- Player helpers --- */
 
-function applyMatrixQualityOnNextPlaying(index, player) {
+function applyMatrixQualityOnNextPlaying(player) {
   if (!player || typeof player.addEventListener !== 'function' || typeof player.removeEventListener !== 'function') return;
-  const existingListener = qualityListeners.get(index);
-  if (existingListener) {
-    player.removeEventListener(Twitch.Player.PLAYING, existingListener);
-  }
   const applyQuality = () => {
     player.removeEventListener(Twitch.Player.PLAYING, applyQuality);
-    qualityListeners.delete(index);
     try { player.setQuality(MATRIX_RESOLUTION_FPS); } catch(e) { /* ignore */ }
   };
-  qualityListeners.set(index, applyQuality);
   player.addEventListener(Twitch.Player.PLAYING, applyQuality);
 }
 
@@ -885,7 +878,7 @@ function setTwitchPlayerChannel(index, channelName) {
   if (!player) return;
   if (typeof player.setChannel === 'function') {
     player.setChannel(channelName);
-    applyMatrixQualityOnNextPlaying(index, player);
+    applyMatrixQualityOnNextPlaying(player);
   } else {
     console.warn(`setChannel not available on player ${index}`);
   }


### PR DESCRIPTION
### Motivation
- Undo the changes from commit `a1f5938` (PR #73) to restore the previous Twitch player quality-listener behavior after the per-slot listener approach proved undesirable.

### Description
- Removed the `qualityListeners` map and reverted `applyMatrixQualityOnNextPlaying` to take only a `player`, removing per-index listener tracking and updating the call site in `setTwitchPlayerChannel` to `applyMatrixQualityOnNextPlaying(player)` in `index.html`.

### Testing
- Ran repository verification commands `git revert --no-edit a1f5938`, `git show --name-only --pretty=oneline HEAD`, `git diff --unified=0 HEAD~1 HEAD -- index.html`, and `git status --short`, all of which completed successfully; no unit or runtime tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17ed39b9d08332b74ee7c2682fa6be)