### PR TITLE
Reapply per-slot PLAYING quality listener cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -858,15 +858,22 @@ let matrixRefreshIntervalId = null;
 let matrixRefreshInProgress = false;
 let matrixCountdownSeconds = 0;
 let matrixResizeHandler = null;
+const qualityListeners = new Map();
 
 /* --- Player helpers --- */
 
-function applyMatrixQualityOnNextPlaying(player) {
+function applyMatrixQualityOnNextPlaying(index, player) {
   if (!player || typeof player.addEventListener !== 'function' || typeof player.removeEventListener !== 'function') return;
+  const existingListener = qualityListeners.get(index);
+  if (existingListener) {
+    player.removeEventListener(Twitch.Player.PLAYING, existingListener);
+  }
   const applyQuality = () => {
     player.removeEventListener(Twitch.Player.PLAYING, applyQuality);
+    qualityListeners.delete(index);
     try { player.setQuality(MATRIX_RESOLUTION_FPS); } catch(e) { /* ignore */ }
   };
+  qualityListeners.set(index, applyQuality);
   player.addEventListener(Twitch.Player.PLAYING, applyQuality);
 }
 
@@ -878,7 +885,7 @@ function setTwitchPlayerChannel(index, channelName) {
   if (!player) return;
   if (typeof player.setChannel === 'function') {
     player.setChannel(channelName);
-    applyMatrixQualityOnNextPlaying(player);
+    applyMatrixQualityOnNextPlaying(index, player);
   } else {
     console.warn(`setChannel not available on player ${index}`);
   }


### PR DESCRIPTION
### Motivation
- Prevent orphaned PLAYING listeners from accumulating on matrix player slots when channels are switched by restoring per-slot listener tracking and cleanup.

### Description
- Add a `qualityListeners` `Map` to track the PLAYING listener per player slot and scope cleanup to a slot index.  
- Change `applyMatrixQualityOnNextPlaying` signature to `applyMatrixQualityOnNextPlaying(index, player)` and remove any existing listener for that index before attaching a new one.  
- Ensure the one-shot listener removes itself and clears the corresponding entry in `qualityListeners` after execution.  
- Update `setTwitchPlayerChannel` to call the revised `applyMatrixQualityOnNextPlaying` with the slot index.

### Testing
- No automated unit tests were added or run for this change.  
- Repository validations were performed and the working tree reflects the intended diff for `index.html` (changes applied successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17eec2cac88332835348a6e16afb09)