### PR TITLE
Fix matrix quality listener cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -883,16 +883,20 @@ const qualityListeners = new Map();
 
 function applyMatrixQualityOnNextPlaying(index, player) {
   if (!player || typeof player.addEventListener !== 'function' || typeof player.removeEventListener !== 'function') return;
-  const existingListener = qualityListeners.get(index);
-  if (existingListener) {
-    player.removeEventListener(Twitch.Player.PLAYING, existingListener);
+  const existing = qualityListeners.get(index);
+  if (existing) {
+    existing.player.removeEventListener(Twitch.Player.PLAYING, existing.listener);
+    qualityListeners.delete(index);
   }
   const applyQuality = () => {
     player.removeEventListener(Twitch.Player.PLAYING, applyQuality);
-    qualityListeners.delete(index);
+    const current = qualityListeners.get(index);
+    if (current && current.listener === applyQuality && current.player === player) {
+      qualityListeners.delete(index);
+    }
     try { player.setQuality(matrixResolution(true)); } catch(e) { /* ignore */ }
   };
-  qualityListeners.set(index, applyQuality);
+  qualityListeners.set(index, { player, listener: applyQuality });
   player.addEventListener(Twitch.Player.PLAYING, applyQuality);
 }
 


### PR DESCRIPTION
### Motivation
- The existing `applyMatrixQualityOnNextPlaying` could leave orphaned `PLAYING` listeners because `removeEventListener` requires the exact function reference that originally registered the listener. 
- When switching channels multiple times before `PLAYING` fires, the newly-created closure could be orphaned on the player and not removable via the single function reference stored in the map. 
- The change ensures the cleanup uses the owning player and the exact listener reference so stale callbacks are removed correctly and cannot delete newer records.

### Description
- Change `qualityListeners` entries to store an object `{ player, listener }` instead of a raw function reference. 
- On new registration, if an `existing` record is present call `existing.player.removeEventListener(Twitch.Player.PLAYING, existing.listener)` and delete the stale record. 
- In the `applyQuality` closure, guard self-cleanup by checking `qualityListeners.get(index)` and only deleting the record if it still matches the current `player` and `listener`. 
- Continue to set the new record with `qualityListeners.set(index, { player, listener: applyQuality })` before calling `player.addEventListener` so subsequent registrations can find and remove it.

### Testing
- Ran a VM-based lifecycle test that simulates players and asserts that replacing listeners removes the exact previous function, cross-player cleanup removes from the player that owns the listener, and stale callbacks cannot remove newer records; the test passed. 
- Ran `git diff --check` to verify no whitespace or diff issues; it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ca4bebee48332aab590fb16514742)