### PR TITLE
Fix matrix layout timing fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -870,6 +870,7 @@ function makePreviewCard(name) {
 
 /* ---------- Matrix Overlay — Twitch.Player persistent ---------- */
 const matrixBackdrop = document.getElementById('matrixBackdrop');
+const matrixHeader = matrixBackdrop.querySelector('.matrix-header');
 const matrixBody = document.getElementById('matrixBody');
 const matrixRefreshCountdownEl = document.getElementById('matrixRefreshCountdown');
 const matrixOnlineFeedEl = document.getElementById('matrixOnlineFeed');
@@ -1173,7 +1174,13 @@ function applyMatrixLayout() {
   }
   const gap = parseFloat(getComputedStyle(matrixBody).gap || "8");
   const rect = matrixBody.getBoundingClientRect();
-  const cols = optimalCols(n, rect.width, rect.height, gap || 8);
+  let width = rect.width;
+  let height = rect.height;
+  if (!width || !height) {
+    width = window.innerWidth;
+    height = Math.max(0, window.innerHeight - (matrixHeader.offsetHeight || 42));
+  }
+  const cols = optimalCols(n, width, height, gap || 8);
   matrixBody.style.gridTemplateColumns = `repeat(${cols}, minmax(0, 1fr))`;
 }
 
@@ -1315,11 +1322,14 @@ function openMatrix() {
 
   renderMatrixOnlineFeed();
   startMatrixRefreshInterval();
-  applyMatrixLayout();
 
-  if (matrixResizeHandler) window.removeEventListener('resize', matrixResizeHandler);
-  matrixResizeHandler = applyMatrixLayout;
-  window.addEventListener('resize', matrixResizeHandler, { passive: true });
+  requestAnimationFrame(() => {
+    applyMatrixLayout();
+
+    if (matrixResizeHandler) window.removeEventListener('resize', matrixResizeHandler);
+    matrixResizeHandler = applyMatrixLayout;
+    window.addEventListener('resize', matrixResizeHandler, { passive: true });
+  });
 }
 
 /* --- closeMatrix — browser refresh for full embed/resource cleanup --- */


### PR DESCRIPTION
### Motivation
- The matrix layout measured zero height when `matrixBody.getBoundingClientRect()` was called immediately after showing the backdrop because the browser had not yet painted.
- Accurate viewport dimensions are required by `optimalCols()` to compute grid columns and avoid incorrect tile sizing on first open.
- The change should not alter the persistent Twitch.Player lifecycle or the subsequent-open reconciliation logic.

### Description
- Cache a reference to the matrix header (`matrixHeader`) so header height can be subtracted when computing a fallback body height. 
- In `applyMatrixLayout()`, fall back to `window.innerWidth` and `window.innerHeight - (matrixHeader.offsetHeight || 42)` when `getBoundingClientRect()` reports zero width or height so `optimalCols()` receives usable dimensions. 
- Defer the initial `applyMatrixLayout()` call and attachment of the resize handler into a `requestAnimationFrame()` callback executed after the backdrop is displayed so measurements occur after layout/paint. 
- Kept player persistence, `setChannel` usage, and reconciliation logic unchanged; only layout timing and the fallback measurement logic were modified. 

### Testing
- Ran a Python content check that verified the added `requestAnimationFrame` call and the fallback expressions `window.innerHeight - (matrixHeader.offsetHeight || 42)` and `window.innerWidth`, which passed. 
- Ran `git diff --check` to ensure no whitespace or diff issues, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a205bad96208332b0edd550a60e5881)