### PR TITLE
Use ResizeObserver for initial matrix layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1323,13 +1323,20 @@ function openMatrix() {
   renderMatrixOnlineFeed();
   startMatrixRefreshInterval();
 
-  requestAnimationFrame(() => {
-    applyMatrixLayout();
+  const ro = new ResizeObserver((entries, observer) => {
+    const entry = entries[0];
+    const w = entry.contentRect.width;
+    const h = entry.contentRect.height;
+    if (w > 0 && h > 0) {
+      observer.disconnect();
+      applyMatrixLayout();
 
-    if (matrixResizeHandler) window.removeEventListener('resize', matrixResizeHandler);
-    matrixResizeHandler = applyMatrixLayout;
-    window.addEventListener('resize', matrixResizeHandler, { passive: true });
+      if (matrixResizeHandler) window.removeEventListener('resize', matrixResizeHandler);
+      matrixResizeHandler = applyMatrixLayout;
+      window.addEventListener('resize', matrixResizeHandler, { passive: true });
+    }
   });
+  ro.observe(matrixBody);
 }
 
 /* --- closeMatrix — browser refresh for full embed/resource cleanup --- */


### PR DESCRIPTION
### Motivation
- The initial `requestAnimationFrame` call sometimes ran before browsers finished layout for a newly shown `display:flex` `matrixBody`, producing zero width/height on Chrome and Firefox, so the layout needs a cross-browser-safe trigger that waits for real dimensions.

### Description
- Replaced the single `requestAnimationFrame` invocation that called `applyMatrixLayout()` with a one-shot `ResizeObserver` that observes `matrixBody`, waits for `entry.contentRect.width` and `height` to be greater than zero, disconnects itself, and then calls `applyMatrixLayout()`.
- Kept the existing resize handler registration (`matrixResizeHandler`) and the fallback dimension logic inside `applyMatrixLayout()` unchanged; the observer sets up the same resize listener after the initial layout is applied.
- Change applied to `index.html` around the `openMatrix()` flow where the initial layout was triggered.

### Testing
- Ran `git diff --check`, which returned no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a205f38ddfc833298d1b2ce7421e2d8)