### PR TITLE
Fix optimal column layout scoring

### DIFF
--- a/index.html
+++ b/index.html
@@ -1132,9 +1132,9 @@ function optimalCols(n, W, H, gap) {
     const tileW = Math.max(0, (W - totalGapW) / cols);
     const tileH = tileW * 9 / 16;
     const gridH = rows * tileH + totalGapH;
-    const area = tileW * tileH;
+    const area = tileW * tileH * (n / (rows * cols));
     const overflow = Math.max(0, gridH - H);
-    const fits = overflow <= 0;
+    const fits = overflow <= H * 0.05;
     if (fits && (area > best.area || (area === best.area && cols > best.cols))) {
       best = {cols, area, overflow};
     }
@@ -1149,7 +1149,7 @@ function optimalCols(n, W, H, gap) {
     const tileH = tileW * 9 / 16;
     const gridH = rows * tileH + totalGapH;
     const overflow = Math.max(0, gridH - H);
-    const area = tileW * tileH;
+    const area = tileW * tileH * (n / (rows * cols));
     if (overflow < minOverflow || (overflow === minOverflow && area > bestArea)) {
       minOverflow = overflow; bestArea = area; bestCols = cols;
     }


### PR DESCRIPTION
### Motivation
- The layout selector previously used raw tile area and a strict `overflow <= 0` fit test, which caused wider-but-sparser grids to beat denser grids with unused slots.

### Description
- In `optimalCols` (in `index.html`) relax the fits condition to allow small height overflow by using `overflow <= H * 0.05`.
- In both the fits loop and the overflow fallback loop replace `area = tileW * tileH` with `area = tileW * tileH * (n / (rows * cols))` so area is weighted by grid fill ratio.
- Both changes are applied to the initial "fits" loop and the subsequent overflow fallback loop inside `optimalCols` and nothing else was modified.

### Testing
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20e3df9b288332a4d3a497b9bb31c9)