### PR TITLE
Remove 5-tile special case and set explicit grid rows for matrix layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1163,15 +1163,6 @@ function applyMatrixLayout() {
   Array.from(tiles).forEach(t => { t.style.gridColumn = ''; t.style.gridRow = ''; });
   matrixBody.style.gridTemplateColumns = '';
   matrixBody.style.gridTemplateRows = '';
-  if (n === 5) {
-    matrixBody.style.gridTemplateColumns = 'repeat(6, minmax(0, 1fr))';
-    if (tiles[0]) tiles[0].style.gridColumn = 'span 3';
-    if (tiles[1]) tiles[1].style.gridColumn = 'span 3';
-    if (tiles[2]) tiles[2].style.gridColumn = 'span 2';
-    if (tiles[3]) tiles[3].style.gridColumn = 'span 2';
-    if (tiles[4]) tiles[4].style.gridColumn = 'span 2';
-    return;
-  }
   const gap = parseFloat(getComputedStyle(matrixBody).gap || "8");
   const rect = matrixBody.getBoundingClientRect();
   let width = rect.width;
@@ -1182,6 +1173,13 @@ function applyMatrixLayout() {
   }
   const cols = optimalCols(n, width, height, gap || 8);
   matrixBody.style.gridTemplateColumns = `repeat(${cols}, minmax(0, 1fr))`;
+  const rows = Math.ceil(n / cols);
+  const rowH = Math.floor((height - gap * (rows - 1)) / rows);
+  matrixBody.style.gridTemplateRows = `repeat(${rows}, ${rowH}px)`;
+  Array.from(matrixBody.children).forEach(t => {
+    t.style.aspectRatio = 'unset';
+    t.style.height = '100%';
+  });
 }
 
 /* --- openMatrix ---


### PR DESCRIPTION
### Motivation

- Remove fragile hardcoded layout for `n === 5` and make the matrix layout consistently responsive for any number of tiles.
- Ensure tiles fill the available vertical space and maintain consistent row heights instead of relying on implicit sizing.

### Description

- Removed the special-case block that created a custom `gridTemplateColumns` and column spans for `n === 5`.
- After computing `cols` with `optimalCols`, added calculation of `rows` and explicit `gridTemplateRows` using a computed `rowH` based on available `height` and `gap`.
- Set each tile's `aspectRatio` to `unset` and `height` to `100%` so tiles stretch to the row height and the grid fills the container.
- Left `optimalCols` usage and other layout fallbacks intact to preserve column selection logic.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21016f3f408332b403a57c2038986c)