### PR TITLE
Fix matrix tile layout: pixel-sized tiles, 1px gap, centered grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,7 +222,8 @@
       overflow:auto;
       padding:2px;
       display:grid;
-      gap:2px;
+      gap:1px;
+      justify-content:center;
       align-content:start;
       background:#000;
     }
@@ -1163,7 +1164,7 @@ function applyMatrixLayout() {
   Array.from(tiles).forEach(t => { t.style.gridColumn = ''; t.style.gridRow = ''; });
   matrixBody.style.gridTemplateColumns = '';
   matrixBody.style.gridTemplateRows = '';
-  const gap = parseFloat(getComputedStyle(matrixBody).gap || "8");
+  const gap = 1;
   const rect = matrixBody.getBoundingClientRect();
   let width = rect.width;
   let height = rect.height;
@@ -1171,14 +1172,18 @@ function applyMatrixLayout() {
     width = window.innerWidth;
     height = Math.max(0, window.innerHeight - (matrixHeader.offsetHeight || 42));
   }
-  const cols = optimalCols(n, width, height, gap || 8);
-  matrixBody.style.gridTemplateColumns = `repeat(${cols}, minmax(0, 1fr))`;
+
+  const cols = optimalCols(n, width, height, gap);
   const rows = Math.ceil(n / cols);
-  const rowH = Math.floor((height - gap * (rows - 1)) / rows);
-  matrixBody.style.gridTemplateRows = `repeat(${rows}, ${rowH}px)`;
+  const tileW = Math.floor((width - gap * (cols - 1)) / cols);
+  const tileH = Math.floor(tileW * 9 / 16);
+  matrixBody.style.gap = `${gap}px`;
+  matrixBody.style.gridTemplateColumns = `repeat(${cols}, ${tileW}px)`;
+  matrixBody.style.gridTemplateRows = `repeat(${rows}, ${tileH}px)`;
   Array.from(matrixBody.children).forEach(t => {
     t.style.aspectRatio = 'unset';
     t.style.height = '100%';
+    t.style.width = '100%';
   });
 }
 


### PR DESCRIPTION
### Motivation

- Reduce visual gaps and ensure tiles maintain a consistent 16:9 aspect while centering the grid in the matrix view.
- Replace fractional responsive column sizing with deterministic pixel dimensions to avoid layout overflow and rounding artifacts.
- Ensure each tile fills its cell in both width and height so embedded players size predictably.

### Description

- Adjusted CSS to reduce the grid gap to `1px` and center the matrix content by adding `justify-content: center` to the matrix container.
- In `applyMatrixLayout()` the gap is now fixed to `1` and is passed to `optimalCols`; tile widths and heights are computed in pixels (`tileW`, `tileH`) to preserve a 16:9 ratio and avoid fractional grid sizing.
- Set `matrixBody.style.gap` explicitly and changed `gridTemplateColumns` and `gridTemplateRows` to use the computed pixel dimensions, and set each tile's `width` and `height` to `100%` while unsetting `aspectRatio` to let the grid cell size drive rendering.

### Testing

- Ran the existing automated test suite with `npm test` and all tests passed.
- Ran linting with `npm run lint` and no issues were reported.
- Performed automated layout verification in headless browser tests to confirm tiles maintain 16:9 sizing and grid centering across viewport sizes, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2116a2c5e4833290e33660ca3f301e)