### PR TITLE
Dual-constraint tile sizing in applyMatrixLayout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1175,7 +1175,17 @@ function applyMatrixLayout() {
 
   const cols = optimalCols(n, width, height, gap);
   const rows = Math.ceil(n / cols);
-  const tileW = Math.floor((width - gap * (cols - 1)) / cols);
+
+  // Size tiles to fit width
+  const tileWfromW = Math.floor((width - gap * (cols - 1)) / cols);
+  const tileHfromW = Math.floor(tileWfromW * 9 / 16);
+
+  // Size tiles to fit height
+  const tileHfromH = Math.floor((height - gap * (rows - 1)) / rows);
+  const tileWfromH = Math.floor(tileHfromH * 16 / 9);
+
+  // Use whichever constraint is tighter
+  const tileW = Math.min(tileWfromW, tileWfromH);
   const tileH = Math.floor(tileW * 9 / 16);
   matrixBody.style.gap = `${gap}px`;
   matrixBody.style.gridTemplateColumns = `repeat(${cols}, ${tileW}px)`;


### PR DESCRIPTION
### Motivation
- Ensure matrix tiles are sized to respect both the available width and height while preserving the 16:9 aspect ratio so the grid does not overflow its container.
- Keep existing grid column/row sizing, `gap`, and per-tile style overrides unchanged so centering and layout behavior remain handled by the container CSS.
- Do not change the `optimalCols` algorithm which still chooses the best column count for given dimensions.

### Description
- Replaced the previous single-line tile sizing in `applyMatrixLayout()` with a dual-constraint calculation that computes `tileWfromW`, `tileHfromW`, `tileHfromH`, and `tileWfromH` and then uses `const tileW = Math.min(tileWfromW, tileWfromH)` and `const tileH = Math.floor(tileW * 9 / 16)` to pick the tighter constraint.
- Left `matrixBody.style.gridTemplateColumns`, `matrixBody.style.gridTemplateRows`, `matrixBody.style.gap`, and the per-tile `width`/`height`/`aspectRatio` overrides to continue using the computed `tileW`/`tileH` values.
- The file modified is `index.html` and `optimalCols` was not changed; no `n === 5` special-case branch was present in this `applyMatrixLayout()` implementation so no special-case update was applied in this file.

### Testing
- Ran `git diff --check` to validate the patch and it completed without errors.
- Verified the change was committed to the repository (commit message: `Fit matrix tiles to width and height`).
- No automated unit tests exist for the layout; manual/visual verification is expected when opening the matrix UI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23213536b08332a1c017b1e7aa3096)