### PR TITLE
Add mobile URL bar collapse nudge

### DIFF
--- a/index.html
+++ b/index.html
@@ -1209,6 +1209,10 @@ function openMatrix() {
     return;
   }
 
+  document.documentElement.style.minHeight = '110vh';
+  window.scrollTo({ top: 1, behavior: 'instant' });
+  document.documentElement.style.minHeight = '';
+
   matrixBackdrop.style.display = 'flex';
   document.body.style.overflow = 'hidden';
 


### PR DESCRIPTION
### Motivation
- Ensure mobile browsers collapse their URL bar synchronously before the fixed matrix overlay is shown so the overlay doesn't lock in an expanded viewport.

### Description
- In `openMatrix()` added a synchronous scroll nudge immediately before showing the backdrop and locking overflow by inserting `document.documentElement.style.minHeight = '110vh';`, `window.scrollTo({ top: 1, behavior: 'instant' });`, and `document.documentElement.style.minHeight = '';` just before `matrixBackdrop.style.display = 'flex';` and `document.body.style.overflow = 'hidden';`.

### Testing
- Ran `git diff --check` to verify no whitespace or diff issues and inspected `index.html` to confirm the three-line insertion; the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2705d3d62c8332ae29b560916a3dce)