### PR TITLE
Fix matrix scroll render timing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1201,7 +1201,7 @@ function applyMatrixLayout() {
    First call: creates Twitch.Player instances and DOM tiles.
    Subsequent calls (refresh): updates existing players via setChannel.
    Players are NEVER destroyed. --------------------------------------- */
-function openMatrix() {
+async function openMatrix() {
   if (!lastLive.length) return;
 
   if (!STATIC_HOST) {
@@ -1209,8 +1209,9 @@ function openMatrix() {
     return;
   }
 
-  document.documentElement.style.minHeight = '110vh';
-  window.scrollTo({ top: 50, behavior: 'instant' });
+  document.documentElement.style.minHeight = '200vh';
+  window.scrollTo({ top: 100, behavior: 'instant' });
+  await new Promise(r => requestAnimationFrame(r));
   document.documentElement.style.minHeight = '';
 
   matrixBackdrop.style.display = 'flex';
@@ -1370,7 +1371,7 @@ function closeMatrix() {
 async function refreshMatrix() {
   await retrieveAll();
   generateFromCache();
-  openMatrix();
+  await openMatrix();
 }
 
 /* --- Event listeners --- */
@@ -1412,7 +1413,7 @@ document.addEventListener("DOMContentLoaded", async ()=>{
 
   document.getElementById("retrieveBtn").onclick = retrieveAll;
   document.getElementById("generateBtn").onclick = generateFromCache;
-  matrixBtn.onclick = openMatrix;
+  matrixBtn.onclick = () => openMatrix().catch(console.error);
   openBtn.onclick = () => finalURL && window.open(finalURL, "_blank");
   multiBtn.onclick = () => multiURL && window.open(multiURL, "_blank");
 


### PR DESCRIPTION
### Motivation
- Ensure the programmatic scroll actually renders before `overflow: hidden` is applied so the matrix open animation/scroll isn't dropped.
- Prevent visual jumpiness when opening the embedded Twitch matrix by forcing a taller document, scrolling, waiting a frame, then restoring layout constraints.
- Make `openMatrix()` awaitable so callers can reliably wait for the matrix to finish opening.

### Description
- Made `openMatrix()` asynchronous by changing it to `async function openMatrix()` and replaced the previous scroll block with:
  - `document.documentElement.style.minHeight = '200vh';`
  - `window.scrollTo({ top: 100, behavior: 'instant' });`
  - `await new Promise(r => requestAnimationFrame(r));`
  - `document.documentElement.style.minHeight = '';`
- Updated `refreshMatrix()` to `await openMatrix()` after `retrieveAll()` and `generateFromCache()`.
- Updated the Matrix button handler to `matrixBtn.onclick = () => openMatrix().catch(console.error);` to handle the async open and surface errors.

### Testing
- Ran a Python assertion script that verifies `async function openMatrix()` and the new `minHeight`/`requestAnimationFrame` block are present, and that `matrixBtn.onclick` was updated; the revised assertions passed.
- Ran `git diff --check` which returned clean results.
- Committed the changes and confirmed the modified lines in `index.html` show the intended diffs (change logged in commit message).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27098b99cc8332a3616c4da3d905f3)