### PR TITLE
Restore matrix open behavior and remove mobile scroll nudge

### DIFF
--- a/index.html
+++ b/index.html
@@ -1201,18 +1201,13 @@ function applyMatrixLayout() {
    First call: creates Twitch.Player instances and DOM tiles.
    Subsequent calls (refresh): updates existing players via setChannel.
    Players are NEVER destroyed. --------------------------------------- */
-async function openMatrix() {
+function openMatrix() {
   if (!lastLive.length) return;
 
   if (!STATIC_HOST) {
     console.error('No hostname — cannot embed Twitch');
     return;
   }
-
-  document.documentElement.style.minHeight = '200vh';
-  window.scrollTo({ top: 100, behavior: 'instant' });
-  await new Promise(r => requestAnimationFrame(r));
-  document.documentElement.style.minHeight = '';
 
   matrixBackdrop.style.display = 'flex';
   document.body.style.overflow = 'hidden';
@@ -1371,7 +1366,7 @@ function closeMatrix() {
 async function refreshMatrix() {
   await retrieveAll();
   generateFromCache();
-  await openMatrix();
+  openMatrix();
 }
 
 /* --- Event listeners --- */
@@ -1413,7 +1408,7 @@ document.addEventListener("DOMContentLoaded", async ()=>{
 
   document.getElementById("retrieveBtn").onclick = retrieveAll;
   document.getElementById("generateBtn").onclick = generateFromCache;
-  matrixBtn.onclick = () => openMatrix().catch(console.error);
+  matrixBtn.onclick = openMatrix;
   openBtn.onclick = () => finalURL && window.open(finalURL, "_blank");
   multiBtn.onclick = () => multiURL && window.open(multiURL, "_blank");
 


### PR DESCRIPTION
### Motivation
- Recent changes introduced a scroll/height nudge and an async open flow for the embedded matrix to try to fix render timing, which caused regressions in matrix opening and refresh behavior. 
- The intent is to restore the previous, stable behavior where the matrix opens immediately and refreshes reuse the same open flow.

### Description
- Removed the temporary document height/scroll nudges (`document.documentElement.style.minHeight` / `window.scrollTo` / `requestAnimationFrame`) from `openMatrix()` so the modal opens directly. 
- Converted `openMatrix()` back to a synchronous function and removed awaiting it from `refreshMatrix()` so refresh calls update and open the matrix inline. 
- Restored `matrixBtn.onclick` to a direct function reference (`matrixBtn.onclick = openMatrix`) rather than wrapping with an async call. 
- Kept DOM/tile/player initialization logic intact while removing the mobile URL-bar collapse workaround and related timing code in `index.html`.

### Testing
- Ran syntax validation on the extracted inline script with `node --check /tmp/twitchmatrix-inline.js` which succeeded. 
- Verified `index.html` matches the expected pre-change version using `git diff --quiet HEAD~6 -- index.html`, which returned no differences.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a270b0a5b4c83329e05bd5afab0e23d)