### PR TITLE
Replace PLAYING listener with 20s timer for matrix quality

### DIFF
--- a/index.html
+++ b/index.html
@@ -449,6 +449,7 @@ const matrixPlayers = new Map();
 const matrixTiles = new Map();
 let matrixInitialized = false;
 const MATRIX_RESOLUTION_DEFAULT = '160p';
+const QUALITY_DELAY_MS = 20000;
 function matrixResolution(forQuality=false) {
   const resolution = document.getElementById('inputResolution')?.value || MATRIX_RESOLUTION_DEFAULT;
   return forQuality ? `${resolution}30` : resolution;
@@ -879,27 +880,27 @@ let matrixRefreshIntervalId = null;
 let matrixRefreshInProgress = false;
 let matrixCountdownSeconds = 0;
 let matrixResizeHandler = null;
-const qualityListeners = new Map();
+const qualityTimers = new Map();
 
 /* --- Player helpers --- */
 
-function applyMatrixQualityOnNextPlaying(index, player) {
-  if (!player || typeof player.addEventListener !== 'function' || typeof player.removeEventListener !== 'function') return;
-  const existing = qualityListeners.get(index);
-  if (existing) {
-    existing.player.removeEventListener(Twitch.Player.PLAYING, existing.listener);
-    qualityListeners.delete(index);
-  }
-  const applyQuality = () => {
-    player.removeEventListener(Twitch.Player.PLAYING, applyQuality);
-    const current = qualityListeners.get(index);
-    if (current && current.listener === applyQuality && current.player === player) {
-      qualityListeners.delete(index);
+function applyMatrixQualityAfterDelay(index, player) {
+  if (!player || typeof player.setQuality !== 'function') return;
+  const existing = qualityTimers.get(index);
+  if (existing) clearTimeout(existing);
+
+  const timerId = setTimeout(() => {
+    if (qualityTimers.get(index) === timerId) {
+      qualityTimers.delete(index);
     }
     try { player.setQuality(matrixResolution(true)); } catch(e) { /* ignore */ }
-  };
-  qualityListeners.set(index, { player, listener: applyQuality });
-  player.addEventListener(Twitch.Player.PLAYING, applyQuality);
+  }, QUALITY_DELAY_MS);
+  qualityTimers.set(index, timerId);
+}
+
+function clearAllQualityTimers() {
+  qualityTimers.forEach((timerId) => clearTimeout(timerId));
+  qualityTimers.clear();
 }
 
 function setTwitchPlayerChannel(index, channelName) {
@@ -910,7 +911,7 @@ function setTwitchPlayerChannel(index, channelName) {
   if (!player) return;
   if (typeof player.setChannel === 'function') {
     player.setChannel(channelName);
-    applyMatrixQualityOnNextPlaying(index, player);
+    applyMatrixQualityAfterDelay(index, player);
   } else {
     console.warn(`setChannel not available on player ${index}`);
   }
@@ -1356,6 +1357,7 @@ function openMatrix() {
 function closeMatrix() {
   closeAllMatrixStreamPickers();
   stopMatrixRefreshInterval();
+  clearAllQualityTimers();
   matrixCountdownSeconds = 0;
   matrixRefreshCountdownEl.textContent = '';
 


### PR DESCRIPTION
### Motivation
- Avoid relying on per-player `PLAYING` listeners to apply quality and instead use a simple per-slot delayed timer to reduce listener churn and races when channels are changed. 

### Description
- Added a tunable constant `const QUALITY_DELAY_MS = 20000` near the top of the script for easy delay tuning. 
- Replaced `qualityListeners` Map with `qualityTimers` Map that stores `setTimeout` IDs keyed by player slot index. 
- Implemented `applyMatrixQualityAfterDelay(index, player)` which cancels any existing timer for that index and schedules a 20s `setTimeout` that calls `player.setQuality(matrixResolution(true))` inside a `try/catch`. 
- Added `clearAllQualityTimers()` to cancel and clear all pending timers and called it from `closeMatrix()` before `window.location.reload()`. 
- Updated all call sites that used `applyMatrixQualityOnNextPlaying` to call `applyMatrixQualityAfterDelay` instead, while leaving the `Twitch.Player.READY` listener on initial player creation untouched. 

### Testing
- Ran a small extraction script to gather inline scripts with `python3` which completed successfully. 
- Performed a JavaScript syntax check via `node --check /tmp/twitchmatrix-index.js` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29a985a2c48332afb2e1a097af6f5c)