### PR TITLE
Preview: z-index bump and tier-stats online preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
       background: rgba(0,0,0,.64);
       display: none;
       align-items: center; justify-content: center;
-      z-index: 9999;
+      z-index: 10001;
     }
     .preview-modal {
       background: #111;
@@ -1154,6 +1154,16 @@ matrixOnlineFeedEl?.addEventListener("click", async (e) => {
   e.preventDefault();
   if (retrievePromise) return;
   await retrieveAll();
+});
+matrixTierStatsEl?.addEventListener("click", (e) => {
+  const pill = e.target.closest(".tier-pill");
+  if (!pill || !matrixTierStatsEl.contains(pill)) return;
+  const feedItems = getOnlineFeedNames();
+  if (!feedItems.length) return;
+  const grid = document.createElement("div");
+  grid.className = "preview-grid";
+  feedItems.forEach(item => grid.appendChild(makePreviewCard(item.name)));
+  openPreview({ title: "Online", nodes: [ grid ] });
 });
 
 /* --- Refresh displayed streams (timer path) --- */


### PR DESCRIPTION
### Motivation
- Ensure the preview overlay appears above the matrix layer so previews are not occluded by other overlays.
- Provide a quick, cache-only way to open an "Online" preview grid from the tier stats pills without triggering any fetch or retrieve flows.

### Description
- Changed `.preview-backdrop` z-index from `9999` to `10001` in `index.html`.
- Added a bare `matrixTierStatsEl` click listener that detects clicks on `.tier-pill`, calls `getOnlineFeedNames()`, returns if the list is empty, builds a `div` with class `preview-grid`, appends `makePreviewCard(item.name)` for each entry, and calls `openPreview({ title: "Online", nodes: [ grid ] })`.
- The new listener is added via `addEventListener` with no `AbortController` and performs no network/fetch/retrieve calls.

### Testing
- Ran `git diff --check` to validate whitespace and basic diffs and it succeeded.
- Extracted inline scripts with a Python parser and ran `node --check /tmp/twitchmatrix-index.js` to validate syntax and it succeeded.
- Attempted an environment check for `playwright` which failed because the tool was not available in the environment (informational failure, not a code regression).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ad7a215908332b0de5501bee0f362)