### PR TITLE
Unify matrix online preview clicks

### DIFF
--- a/index.html
+++ b/index.html
@@ -1150,20 +1150,24 @@ function renderMatrixOnlineFeed() {
     .join('');
   matrixOnlineFeedEl.innerHTML = `<span class="matrix-online-feed-segment">${markup}</span>`;
 }
-matrixOnlineFeedEl?.addEventListener("click", async (e) => {
-  e.preventDefault();
-  if (retrievePromise) return;
+async function retrieveThenOpenOnlinePreview() {
   await retrieveAll();
-});
-matrixTierStatsEl?.addEventListener("click", (e) => {
-  const pill = e.target.closest(".tier-pill");
-  if (!pill || !matrixTierStatsEl.contains(pill)) return;
   const feedItems = getOnlineFeedNames();
   if (!feedItems.length) return;
   const grid = document.createElement("div");
   grid.className = "preview-grid";
   feedItems.forEach(item => grid.appendChild(makePreviewCard(item.name)));
   openPreview({ title: "Online", nodes: [ grid ] });
+}
+matrixOnlineFeedEl?.addEventListener("click", async (e) => {
+  e.preventDefault();
+  await retrieveThenOpenOnlinePreview();
+});
+matrixTierStatsEl?.addEventListener("click", async (e) => {
+  const pill = e.target.closest(".tier-pill");
+  if (!pill || !matrixTierStatsEl.contains(pill)) return;
+  e.preventDefault();
+  await retrieveThenOpenOnlinePreview();
 });
 
 /* --- Refresh displayed streams (timer path) --- */


### PR DESCRIPTION
### Motivation
- Make the online-name feed and the tier-pill preview open the identical thumbnail overlay after ensuring the latest statuses are retrieved, so both UI affordances behave the same way.

### Description
- Added a shared helper `retrieveThenOpenOnlinePreview()` that calls `retrieveAll()` then builds and opens the online preview grid using `getOnlineFeedNames()` and `makePreviewCard()`; updated `index.html` accordingly.
- Rewired the `matrixOnlineFeedEl` and `matrixTierStatsEl` click handlers to call the shared helper and made the tier-pill handler `async` with `e.preventDefault()` to use the unified flow.

### Testing
- Ran an inline script extraction with `python` which reported the inline script was extracted successfully. 
- Performed a syntax check with `node --check /tmp/twitchmatrix-inline.js` which completed with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d804bf4688332a4de591c2baac5c6)