### PR TITLE
Preserve live tiles and reuse previous candidates in openMatrix

### DIFF
--- a/index.html
+++ b/index.html
@@ -1326,6 +1326,28 @@ function openMatrix() {
     matrixInitialized = true;
 
   } else {
+    const currentLive = getDisplayedMatrixStreams();
+    const candidates = lastLive.slice();
+
+    const kept = new Set(
+      currentLive
+        .filter(n => resultsCache.get(n)?.isLive)
+        .map(n => n.toLowerCase())
+    );
+
+    let ci = 0;
+    lastLive = currentLive.map(name => {
+      if (resultsCache.get(name)?.isLive) return name;
+      while (ci < candidates.length) {
+        const pick = candidates[ci++];
+        if (!kept.has(pick.toLowerCase())) {
+          kept.add(pick.toLowerCase());
+          return pick;
+        }
+      }
+      return name;
+    });
+
     /* Subsequent opens — reconcile target list against current slots.
        Preserve slots whose streamer is still desired, and only setChannel
        on slots that truly need a new streamer. */


### PR DESCRIPTION
### Motivation
- Prevent unnecessary channel changes and visual flicker when reopening the matrix by keeping currently displayed live streamers in their slots. 
- Prefer reusing previous `lastLive` candidates only for slots where the displayed streamer is offline to minimize churn and API calls.

### Description
- Added logic in `openMatrix()` to compute `currentLive`, `candidates`, and a `kept` set and to rebuild `lastLive` by preserving displayed names that are still live and filling other slots from previous candidates. 
- The existing reconciliation that computes `desiredNames` and assigns `setChannel` only to slots that truly need replacement remains in place to minimize player changes.

### Testing
- Ran the repository's automated unit tests and lint checks; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3668f76a148332b42df536e31e66a8)