### PR TITLE
Select lowest available Twitch player quality fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -888,6 +888,39 @@ const qualityTimers = new Map();
 
 /* --- Player helpers --- */
 
+function applyBestQuality(player, desiredQuality) {
+  try {
+    if (!player || typeof player.setQuality !== 'function') return;
+
+    let qualities;
+    try {
+      qualities = player.getQualities();
+    } catch(e) {
+      player.setQuality(desiredQuality);
+      return;
+    }
+
+    if (!Array.isArray(qualities) || qualities.length === 0) {
+      player.setQuality(desiredQuality);
+      return;
+    }
+
+    const entries = qualities
+      .filter((entry) => entry && entry.name !== 'auto' && entry.name !== '' && entry.height > 0)
+      .sort((a, b) => a.height - b.height);
+
+    const targetHeight = Number.parseInt(String(desiredQuality).split('p')[0], 10);
+    const matchingEntry = entries.find((entry) => entry.height === targetHeight);
+
+    if (matchingEntry) {
+      player.setQuality(matchingEntry.name);
+      return;
+    }
+
+    player.setQuality(entries[0].name);
+  } catch(e) { /* ignore */ }
+}
+
 function applyMatrixQualityAfterDelay(index, player) {
   if (!player || typeof player.setQuality !== 'function') return;
   const existing = qualityTimers.get(index);
@@ -897,7 +930,7 @@ function applyMatrixQualityAfterDelay(index, player) {
     if (qualityTimers.get(index) === timerId) {
       qualityTimers.delete(index);
     }
-    try { player.setQuality(matrixResolution(true)); } catch(e) { /* ignore */ }
+    applyBestQuality(player, matrixResolution(true));
   }, QUALITY_DELAY_MS);
   qualityTimers.set(index, timerId);
 }
@@ -1319,7 +1352,7 @@ function openMatrix() {
       });
       matrixPlayers.set(index, player);
       player.addEventListener(Twitch.Player.READY, () => {
-        try { player.setQuality(matrixResolution(true)); } catch(e) { /* ignore if unavailable */ }
+        applyBestQuality(player, matrixResolution(true));
       });
     });
 


### PR DESCRIPTION
### Motivation
- Prevent Twitch from silently falling back to `auto` (which can enable high-bitrate playback) when the requested quality is not available. 
- Prefer applying the requested quality when present and otherwise choose a safe low-bitrate fallback to reduce bandwidth and CPU for multistream tiles.

### Description
- Add `applyBestQuality(player, desiredQuality)` which calls `player.getQualities()`, falls back to `player.setQuality(desiredQuality)` on error or empty result, filters out `auto`/empty/zero-height entries, sorts by `height` ascending, parses the numeric height from `desiredQuality`, picks a matching height if present, otherwise selects the lowest available entry, and wraps the logic in `try/catch`.
- Replace direct `player.setQuality(matrixResolution(true))` calls with `applyBestQuality(player, matrixResolution(true))` in the delayed timer function `applyMatrixQualityAfterDelay` and in the `Twitch.Player.READY` handler.
- Keep existing timer behavior, `QUALITY_DELAY_MS`, `qualityTimers`, and `matrixResolution()` unchanged.

### Testing
- Extracted the inline script and ran `node --check /tmp/twitchmatrix-index.js` to validate the synthesized script for syntax errors, which succeeded. 
- Ran `rg -n "setQuality\(" index.html` to verify the `setQuality` call sites were updated to use `applyBestQuality`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a366e008b50833291de178ca9f05c92)