### PR TITLE
Initialize Twitch matrix player quality safely on READY

### DIFF
--- a/index.html
+++ b/index.html
@@ -888,6 +888,13 @@ const qualityTimers = new Map();
 
 /* --- Player helpers --- */
 
+function applyInitialMatrixQuality(player) {
+  try {
+    if (!player || typeof player.setQuality !== 'function') return;
+    player.setQuality(matrixResolution(true));
+  } catch(e) { /* ignore */ }
+}
+
 function applyBestQuality(player, desiredQuality) {
   try {
     if (!player || typeof player.setQuality !== 'function') return;
@@ -1352,7 +1359,7 @@ function openMatrix() {
       });
       matrixPlayers.set(index, player);
       player.addEventListener(Twitch.Player.READY, () => {
-        applyBestQuality(player, matrixResolution(true));
+        applyInitialMatrixQuality(player);
       });
     });
 


### PR DESCRIPTION
### Motivation
- Ensure the persistent Twitch.Player instances in the matrix set the desired initial quality immediately on `READY` without invoking the heavier `applyBestQuality` path or risking uncaught errors from `getQualities`.

### Description
- Add a new helper `applyInitialMatrixQuality` that safely calls `player.setQuality(matrixResolution(true))` inside guards and `try/catch`, and replace the `applyBestQuality(player, matrixResolution(true))` call in the player `READY` handler with `applyInitialMatrixQuality(player)`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36c514eaa883328f4c1a3ef40b15cd)