### PR TITLE
Refresh stale matrix picker cache

### DIFF
--- a/index.html
+++ b/index.html
@@ -435,6 +435,7 @@ const matrixRefreshBtn = document.getElementById("matrixRefreshBtn");
 let finalURL = "", multiURL = "";
 let lastLive = [];
 const resultsCache = new Map();
+let lastRetrieveTime = 0;
 let sessionPins = new Set();
 let sessionBlacklist = new Set();
 
@@ -719,6 +720,7 @@ async function retrieveAll(){
       statusEl.textContent = "Retrieve complete. Click Generate to pick from cache.";
       renderTierOnlineSnapshot();
       renderMatrixOnlineFeed();
+      lastRetrieveTime = Date.now();
     }catch(e){
       console.error(e);
       statusEl.textContent = "Retrieve failed (categories or status). See console for details.";
@@ -1114,8 +1116,13 @@ function doSwap(sourceTile, targetName) {
   renderMatrixOnlineFeed();
 }
 
-function openMatrixTilePicker(tile) {
+async function openMatrixTilePicker(tile) {
   if (!tile) return;
+
+  const PICKER_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+  if (Date.now() - lastRetrieveTime > PICKER_CACHE_TTL_MS) {
+    await retrieveAll();
+  }
 
   const currentName = tile.dataset.streamer || '';
   const swapCandidates = getDisplayedMatrixStreams()
@@ -1494,12 +1501,12 @@ async function refreshMatrix() {
 
 /* --- Event listeners --- */
 matrixBackdrop.querySelector('.matrix-close').addEventListener('click', closeMatrix);
-matrixBody.addEventListener('click', (e) => {
+matrixBody.addEventListener('click', async (e) => {
   const nameButton = e.target.closest('.matrix-streamer-name[data-role="matrix-name-picker"]');
   if (nameButton) {
     e.stopPropagation();
     const tile = nameButton.closest('.tile');
-    openMatrixTilePicker(tile);
+    await openMatrixTilePicker(tile);
     return;
   }
   closeAllMatrixStreamPickers();


### PR DESCRIPTION
### Motivation
- Prevent the matrix tile picker from showing stale stream metadata when the cached `resultsCache` is old by ensuring a fresh `retrieveAll()` is performed before building picker candidates.
- Rely on the existing `retrievePromise` dedupe so concurrent calls remain safe while allowing UI paths to await an up-to-date cache.
- Keep the TTL short and non-configurable to reduce unexpected stale previews (10 minutes chosen).

### Description
- Added a module-level `let lastRetrieveTime = 0;` to track the timestamp of the last successful `retrieveAll()` run.
- Set `lastRetrieveTime = Date.now();` at the end of `retrieveAll()` only on success (before the `catch`/`finally` path) so failures don't update the timestamp.
- Converted `openMatrixTilePicker(tile)` to `async` and added a `PICKER_CACHE_TTL_MS = 10 * 60 * 1000` check that `await retrieveAll()` when the cache is older than 10 minutes.
- Made the matrix body click handler async and `await openMatrixTilePicker(tile)` so the picker waits for the retrieval when needed.

### Testing
- Ran `git diff --check` to validate no whitespace/diff issues and it succeeded.
- Verified repository state with `git status --short` which showed the committed changes.
- Committed the edit and created the PR; the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36f255f8108332b93c333c014eb0b2)