### PR TITLE
Add per-tile quality button to Twitch matrix

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,6 +249,10 @@
       top:6px; right:6px;
       color:#9ca3af; border-radius:4px; font-size:13px; font-weight:700; line-height:1;
     }
+    .matrix-quality-btn {
+      top:6px; left:6px;
+      color:#9ca3af; border-radius:4px; font-size:13px; font-weight:700; line-height:1;
+    }
     .matrix-blacklist.state-pinned { color:#22c55e; }
     .matrix-blacklist.state-blacklisted { color:#ff5555; }
     .matrix-streamer-name{
@@ -1339,6 +1343,15 @@ function openMatrix() {
       playerDiv.className = 'twitch-player-div';
       tile.appendChild(playerDiv);
 
+      const qualityBtn = document.createElement('button');
+      qualityBtn.type = 'button';
+      qualityBtn.className = 'matrix-tile-button matrix-quality-btn';
+      qualityBtn.textContent = '↺';
+      qualityBtn.title = 'Apply selected quality';
+      qualityBtn.onclick = () => {
+        applyBestQuality(player, matrixResolution(true));
+      };
+
       const xbtn = document.createElement('button');
       xbtn.className = 'matrix-tile-button matrix-blacklist';
       setMatrixPinStateButtonStyle(xbtn, name);
@@ -1351,7 +1364,7 @@ function openMatrix() {
       nameBadge.title = 'Change stream';
       nameBadge.dataset.role = 'matrix-name-picker';
 
-      tile.append(xbtn, nameBadge);
+      tile.append(qualityBtn, xbtn, nameBadge);
       matrixBody.appendChild(tile);
       matrixTiles.set(index, tile);
 


### PR DESCRIPTION
### Motivation
- Provide a quick way for users to apply the selected stream quality to an individual tile in the Twitch matrix UI.

### Description
- Add CSS rule `.matrix-quality-btn` to style a new per-tile quality button. 
- Create and insert a `button` into each tile with class `matrix-tile-button matrix-quality-btn`, label `↺`, and title `Apply selected quality`. 
- Wire the button's `onclick` to call `applyBestQuality(player, matrixResolution(true))` for the corresponding `Twitch.Player` instance.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37f6bda3948332bb88af292474a1f2)