### PR TITLE
Add direct-streamer input to matrix tile picker and style preview title

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,9 +122,22 @@
       gap: 10px; padding: 10px 12px; border-bottom: 1px solid var(--border);
     }
     .preview-title { font-weight: 600; color: #eee; }
+    .preview-title.matrix-picker-title { flex: 1; text-align: center; }
     .preview-close { cursor: pointer; font-size: 20px; line-height: 1; background: none; border: 0; color: #ddd; }
     .preview-close:hover { color: #fff; }
     .preview-body { padding: 12px; overflow: auto; }
+    .matrix-picker-input {
+      display: block;
+      width: min(100%, 420px);
+      margin: 0 auto;
+      padding: 8px 10px;
+      border-radius: 8px;
+      border: 1px solid var(--border);
+      background: var(--panel);
+      color: #f5f5f7;
+      font-size: 14px;
+      text-align: center;
+    }
     .preview-grid { display: grid; gap: 12px; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
     .preview-card { border: 1px solid var(--border); border-radius: 10px; overflow: hidden; background: var(--panel); }
     .preview-card img { display: block; width: 100%; height: auto; }
@@ -847,7 +860,9 @@ function initPersistence(){
 /* ---------- Preview Overlay ---------- */
 const previewBackdrop = document.getElementById('previewBackdrop');
 function openPreview({ title, nodes }) {
-  previewBackdrop.querySelector('.preview-title').textContent = title || '';
+  const titleEl = previewBackdrop.querySelector('.preview-title');
+  titleEl.classList.remove('matrix-picker-title');
+  titleEl.textContent = title || '';
   const body = previewBackdrop.querySelector('.preview-body');
   body.innerHTML = '';
   nodes.forEach(n => body.appendChild(n));
@@ -1135,9 +1150,24 @@ async function openMatrixTilePicker(tile) {
   const swapCandidates = getDisplayedMatrixStreams()
     .filter(name => String(name).toLowerCase() !== String(currentName).toLowerCase());
   const replaceCandidates = getMatrixReplacementCandidates(currentName);
-  if (!swapCandidates.length && !replaceCandidates.length) return;
 
   const container = document.createElement('div');
+  const streamerInput = document.createElement('input');
+  streamerInput.className = 'matrix-picker-input';
+  streamerInput.type = 'text';
+  streamerInput.placeholder = 'Enter streamer name…';
+  streamerInput.autocomplete = 'off';
+  streamerInput.autocorrect = 'off';
+  streamerInput.autocapitalize = 'off';
+  streamerInput.spellcheck = false;
+  streamerInput.inputMode = 'url';
+  streamerInput.addEventListener('keydown', (e) => {
+    if (e.key !== 'Enter') return;
+    const nextName = streamerInput.value.trim();
+    if (!nextName) return;
+    replaceMatrixTileStream(tile, nextName);
+    closePreview();
+  });
 
   if (swapCandidates.length) {
     const label = document.createElement('div');
@@ -1174,6 +1204,10 @@ async function openMatrixTilePicker(tile) {
   }
 
   openPreview({ title: currentName, nodes: [container] });
+  const title = previewBackdrop.querySelector('.preview-title');
+  title.classList.add('matrix-picker-title');
+  title.textContent = '';
+  title.appendChild(streamerInput);
 }
 
 /* --- Feed --- */


### PR DESCRIPTION
### Motivation
- Provide a quick way to type a streamer name into the matrix tile picker when swapping or replacing tiles instead of selecting from suggestions.
- Ensure the preview overlay title accommodates the inline input and is centered when acting as the matrix picker header.
- Keep the picker accessible even when there are no swap/replacement suggestions.

### Description
- Added a centered title variant by introducing the `.preview-title.matrix-picker-title` rule to adjust layout for the matrix picker header.
- Introduced a styled text input `.matrix-picker-input` and created an input element in `openMatrixTilePicker` with attributes to disable autocorrect/capitalize and to handle `Enter` for submission.
- Modified `openPreview` to remove the `matrix-picker-title` class for normal previews and updated `openMatrixTilePicker` to add the class, clear the title, and append the streamer input; the input `keydown` handler calls `replaceMatrixTileStream` and `closePreview` on `Enter`.
- Removed the early return in `openMatrixTilePicker` so the picker (and the new input) can open even when there are no swap/replace candidates.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a384f2ba41c8332ad83cf85363011c4)