### PR TITLE
Preserve displayed stream cache entries

### DIFF
--- a/index.html
+++ b/index.html
@@ -687,7 +687,7 @@ async function fetchCategoryTop(catName, limit){
   return [];
 }
 function pruneResultsCacheToVisibleNames() {
-  const visibleNames = new Set(tiers.flat());
+  const visibleNames = new Set([...tiers.flat(), ...getDisplayedMatrixStreams()]);
   for (const name of resultsCache.keys()) {
     if (!visibleNames.has(name)) resultsCache.delete(name);
   }


### PR DESCRIPTION
### Motivation
- Prevent manually entered or off-list streamers that occupy matrix tiles from losing their cached `isLive` status during `retrieveAll()` by ensuring they are considered visible when pruning the results cache.

### Description
- Update `pruneResultsCacheToVisibleNames()` to build `visibleNames` as `new Set([...tiers.flat(), ...getDisplayedMatrixStreams()])` so currently displayed tile streamers are preserved in `resultsCache`.

### Testing
- Ran `node --check /tmp/twitchmatrix-inline.js` to validate inline script syntax and it succeeded.
- Ran `git diff --check` to verify whitespace/patch issues and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3860fb09ec833294d0ce32d8fdbfa7)