### PR TITLE
Fetch displayed picker stream statuses

### DIFF
--- a/index.html
+++ b/index.html
@@ -722,7 +722,7 @@ async function retrieveAll(full = false){
       savePinBlacklistCookies();
       syncPinBlacklistButtons();
       const statusTiers = full ? tiers : [tier1, tier2, tier3];
-      const allNames=[...new Set(statusTiers.flat())];
+      const allNames = [...new Set([...statusTiers.flat(), ...getDisplayedMatrixStreams()])];
       const batchSize=getBatchSize();
       let processed=0;
       for(let i=0; i<allNames.length; ){


### PR DESCRIPTION
### Motivation
- Ensure streamers manually added or currently shown in the matrix picker are included when building the list of names to fetch statuses for, so picker-added names stay refreshed even when outside the default tier set.

### Description
- Update `retrieveAll` in `index.html` to compute `allNames` as `new Set([...statusTiers.flat(), ...getDisplayedMatrixStreams()])` so displayed picker streams are included in the status fetch batch.

### Testing
- Extracted script blocks from `index.html` with a `python3` script and ran `node --check /tmp/twitchmatrix-index-scripts.js`, which passed, and ran `git diff --check`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38639096448332a4d74454f65e6691)