### PR TITLE
Preserve preview title and update matrix tile picker headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -1168,14 +1168,19 @@ async function openMatrixTilePicker(tile) {
     replaceMatrixTileStream(tile, nextName);
     closePreview();
   });
+  container.appendChild(streamerInput);
 
   if (swapCandidates.length) {
     const label = document.createElement('div');
-    label.textContent = '↔ Swap with';
-    label.style.color = '#3dd6f5';
-    label.style.fontSize = '12px';
+    label.textContent = 'Swap with';
+    label.style.color = '#a3e635';
+    label.style.position = 'sticky';
+    label.style.top = '0';
+    label.style.zIndex = '2';
+    label.style.background = '#111';
+    label.style.fontSize = '16px';
     label.style.fontWeight = '700';
-    label.style.padding = '4px 0 6px';
+    label.style.padding = '8px 0 6px';
     container.appendChild(label);
 
     const grid = document.createElement('div');
@@ -1189,10 +1194,14 @@ async function openMatrixTilePicker(tile) {
   if (replaceCandidates.length) {
     const label = document.createElement('div');
     label.textContent = 'Replace with';
-    label.style.color = '#a3e635';
-    label.style.fontSize = '12px';
+    label.style.color = '#3dd6f5';
+    label.style.position = 'sticky';
+    label.style.top = '0';
+    label.style.zIndex = '2';
+    label.style.background = '#111';
+    label.style.fontSize = '16px';
     label.style.fontWeight = '700';
-    label.style.padding = '12px 0 6px';
+    label.style.padding = '8px 0 6px';
     container.appendChild(label);
 
     const grid = document.createElement('div');
@@ -1204,10 +1213,7 @@ async function openMatrixTilePicker(tile) {
   }
 
   openPreview({ title: currentName, nodes: [container] });
-  const title = previewBackdrop.querySelector('.preview-title');
-  title.classList.add('matrix-picker-title');
-  title.textContent = '';
-  title.appendChild(streamerInput);
+  previewBackdrop.querySelector('.preview-body').scrollTop = 0;
 }
 
 /* --- Feed --- */


### PR DESCRIPTION
### Motivation

- Keep the preview title shown by `openPreview` intact while placing the streamer input inside the picker body so the preview header remains unchanged. 
- Improve the visual clarity of the picker by updating the Swap/Replace section labels and making their headers sticky for better scrolling behavior. 

### Description

- Move the streamer input into the picker container by calling `container.appendChild(streamerInput)` before labels/grids are appended so the preview title provided to `openPreview({ title: currentName, ... })` is not cleared or replaced. 
- Change the Swap label text from `↔ Swap with` to `Swap with` and update its color to `#a3e635`. 
- Swap the Replace label color to `#3dd6f5`. 
- Make both section labels sticky by setting `position: sticky`, `top: 0`, `zIndex: 2`, `background: #111`, increase `fontSize` to `16px`, and set `padding: '8px 0 6px'`. 
- After calling `openPreview`, reset the picker scroll position with `previewBackdrop.querySelector('.preview-body').scrollTop = 0;`. 

### Testing

- Ran `git diff -- index.html` to review the changes and it displayed the intended diff (succeeded). 
- Ran `git diff --check` to validate whitespace and patch issues and it returned no problems (succeeded). 
- Ran `git status --short` and performed a commit of the updated file which completed successfully (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ab7e7f2408332b6279b6045d96e76)