### PR TITLE
Allow cancelling pending quality apply for matrix tile button

### DIFF
--- a/index.html
+++ b/index.html
@@ -1387,6 +1387,13 @@ function openMatrix() {
       qualityBtn.textContent = '↺';
       qualityBtn.title = 'Apply selected quality';
       qualityBtn.onclick = () => {
+        const existing = qualityTimers.get(index);
+        if (existing) {
+          clearTimeout(existing);
+          qualityTimers.delete(index);
+          return;
+        }
+
         applyBestQuality(player, matrixResolution(true));
       };
 


### PR DESCRIPTION
### Motivation
- Enable users to cancel a previously scheduled quality-apply action by clicking the matrix tile quality button again.

### Description
- Modify `qualityBtn.onclick` to check `qualityTimers.get(index)` and if present clear the timeout and delete the entry, otherwise call `applyBestQuality(player, matrixResolution(true))`.

### Testing
- Ran the existing automated test suite and linting with no changes to tests; the suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ca8a59ca4833298353b9a1312b327)