### PR TITLE
Improve matrix tile click targets

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,6 +257,11 @@
       border:0; cursor:pointer; z-index:2; font-size:16px;
     }
     .matrix-tile-button:hover { background:rgba(0,0,0,.8); }
+    .matrix-tile-button::before,
+    .matrix-streamer-name::before{
+      content:""; position:absolute; inset:-10px;
+      background:transparent;
+    }
     .matrix-blacklist {
       top:6px; right:6px;
       color:#9ca3af; border-radius:4px; font-size:13px; font-weight:700; line-height:1;
@@ -266,8 +271,8 @@
       color:#9ca3af; border-radius:4px; font-size:13px; font-weight:700; line-height:1;
     }
     .matrix-quality-btn.timer-pending { color: #ff9500 !important; }
-    .quality-dropdown { position: fixed; z-index: 10002; background: rgba(10,10,10,.96); border: 1px solid var(--border); border-radius: 6px; min-width: 150px; overflow: hidden; box-shadow: 0 4px 20px rgba(0,0,0,.6); }
-    .quality-dropdown-item { display: block; width: 100%; padding: 7px 12px; background: none; border: 0; color: #f5f5f7; font-size: 12px; text-align: left; cursor: pointer; white-space: nowrap; }
+    .quality-dropdown { position: fixed; z-index: 10002; background: rgba(10,10,10,.96); border: 1px solid var(--border); border-radius: 6px; min-width: 190px; overflow: hidden; box-shadow: 0 4px 20px rgba(0,0,0,.6); }
+    .quality-dropdown-item { display: block; width: 100%; padding: 11px 16px; background: none; border: 0; color: #f5f5f7; font-size: 14px; text-align: left; cursor: pointer; white-space: nowrap; }
     .quality-dropdown-item:hover { background: rgba(255,255,255,.1); }
     .quality-dropdown-item.danger { color: #ff6b6b; }
     .quality-dropdown-sep { height: 1px; background: var(--border); margin: 2px 0; }


### PR DESCRIPTION
### Motivation
- Make the three small controls on each matrix tile (quality button, name picker, pin/blacklist) easier to hit and make the quality selector list easier to read and tap without changing the visible control sizes.

### Description
- Added invisible expanded hit areas by introducing `::before` pseudo-elements for `.matrix-tile-button` and `.matrix-streamer-name` to increase clickable region without altering visible layout in `index.html`.
- Increased the quality dropdown `min-width` and bumped `.quality-dropdown-item` padding and `font-size` to make list items larger and easier to select in `index.html`.

### Testing
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a407207d2d483328df7ece3bfd7f0c7)