### PR TITLE
Adjust tile overlay button hit zones

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,43 +250,60 @@
     .tile .twitch-player-div { position:absolute; inset:0; width:100%; height:100%; }
 
     .matrix-tile-button {
-      position:absolute;
-      width:22px; height:22px;
-      display:flex; align-items:center; justify-content:center;
-      background:rgba(0,0,0,.65);
-      border:0; cursor:pointer; z-index:2; font-size:16px;
+      position: absolute;
+      display: flex; align-items: center; justify-content: center;
+      background: rgba(0,0,0,.60);
+      border: 0; cursor: pointer; z-index: 2;
     }
-    .matrix-tile-button:hover { background:rgba(0,0,0,.8); }
+    .matrix-tile-button:hover { background: rgba(0,0,0,.82); }
     .matrix-tile-button::before,
-    .matrix-streamer-name::before{
-      content:""; position:absolute; inset:-10px;
-      background:transparent;
+    .matrix-streamer-name::before {
+      content: ""; position: absolute; inset: -10px;
+      background: transparent;
     }
-    .matrix-blacklist {
-      top:6px; right:6px;
-      color:#9ca3af; border-radius:4px; font-size:13px; font-weight:700; line-height:1;
-    }
+
     .matrix-quality-btn {
-      top:6px; left:6px;
-      color:#9ca3af; border-radius:4px; font-size:13px; font-weight:700; line-height:1;
+      top: 0; left: 0;
+      width: 52px; height: 52px;
+      border-radius: 0 0 12px 0;
+      font-size: 18px; font-weight: 700;
+      color: #9ca3af;
+      padding: 0;
     }
     .matrix-quality-btn.timer-pending { color: #ff9500 !important; }
+
+    .matrix-blacklist {
+      top: 0; right: 0;
+      width: 52px; height: 52px;
+      border-radius: 0 0 0 12px;
+      font-size: 15px; font-weight: 700;
+      color: #9ca3af;
+      padding: 0;
+    }
+    .matrix-blacklist.state-pinned     { color: #22c55e; }
+    .matrix-blacklist.state-blacklisted { color: #ff5555; }
+
+    .matrix-streamer-name {
+      position: absolute;
+      top: 0; left: 50%; transform: translateX(-50%);
+      z-index: 2;
+      height: 48px;
+      line-height: 48px;
+      padding: 0 10px;
+      max-width: calc(100% - 112px); /* leave 52px gap on each side for corner buttons */
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+      background: rgba(0,0,0,.72); color: #fff;
+      border-radius: 0 0 8px 8px;   /* flat top, rounds bottom corners only */
+      font-size: 12px; font-weight: 600;
+      pointer-events: auto; border: 1px solid transparent; cursor: pointer;
+      border-top: none;
+    }
+    .matrix-streamer-name:hover { border-color: rgba(255,255,255,.35); border-top: none; }
     .quality-dropdown { position: fixed; z-index: 10002; background: rgba(10,10,10,.96); border: 1px solid var(--border); border-radius: 6px; min-width: 190px; overflow: hidden; box-shadow: 0 4px 20px rgba(0,0,0,.6); }
     .quality-dropdown-item { display: block; width: 100%; padding: 11px 16px; background: none; border: 0; color: #f5f5f7; font-size: 14px; text-align: left; cursor: pointer; white-space: nowrap; }
     .quality-dropdown-item:hover { background: rgba(255,255,255,.1); }
     .quality-dropdown-item.danger { color: #ff6b6b; }
     .quality-dropdown-sep { height: 1px; background: var(--border); margin: 2px 0; }
-    .matrix-blacklist.state-pinned { color:#22c55e; }
-    .matrix-blacklist.state-blacklisted { color:#ff5555; }
-    .matrix-streamer-name{
-      position:absolute; top:6px; left:50%; transform:translateX(-50%);
-      z-index:2; padding:2px 6px; max-width:62%;
-      overflow:hidden; text-overflow:ellipsis; white-space:nowrap;
-      background:rgba(0,0,0,.72); color:#fff; border-radius:4px;
-      font-size:11px; line-height:1.2; font-weight:600;
-      pointer-events:auto; border:1px solid transparent; cursor:pointer;
-    }
-    .matrix-streamer-name:hover{ border-color:rgba(255,255,255,.35); }
     .matrix-streamer-picker{
       position:absolute; top:30px; left:50%; transform:translateX(-50%);
       z-index:3; max-width:70%;


### PR DESCRIPTION
### Motivation
- Make the per-tile overlay controls easier to activate by increasing corner hit zones and consolidating positioning into CSS-only rules. 
- Preserve existing JavaScript behavior while improving visual and interactive consistency of the corner buttons and streamer name badge. 

### Description
- Replaced CSS for `.matrix-tile-button`, `.matrix-quality-btn`, `.matrix-blacklist`, and `.matrix-streamer-name` in `index.html` to provide shared absolute positioning, larger 52px corner hit zones, and transparent expanded hit areas via `::before`.
- Adjusted hover/background styling for `.matrix-tile-button` and `.matrix-streamer-name` and standardized colors, font sizing, padding, and border-radius for the corner buttons.
- Removed the prior inline `top`, `left`, `right`, `font-size`, `font-weight`, `color`, `border-radius`, `padding`, and size properties from the old `.matrix-blacklist` and `.matrix-quality-btn` blocks so sizing/placement are now controlled by the new rules.
- All changes are CSS-only and do not modify any JavaScript logic or event handlers. 

### Testing
- Ran `git diff --check` which reported no whitespace/syntax issues and passed. 
- Verified a commit was created for `index.html` with the CSS updates (commit recorded successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4077d4a4948332ad745bf898afeb7b)