### PR TITLE
Make matrix tile controls transparent

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,10 +252,10 @@
     .matrix-tile-button {
       position: absolute;
       display: flex; align-items: center; justify-content: center;
-      background: rgba(0,0,0,.60);
+      background: transparent;
       border: 0; cursor: pointer; z-index: 2;
     }
-    .matrix-tile-button:hover { background: rgba(0,0,0,.82); }
+    .matrix-tile-button:hover { background: transparent; }
     .matrix-tile-button::before,
     .matrix-streamer-name::before {
       content: ""; position: absolute; inset: -10px;
@@ -292,7 +292,7 @@
       padding: 0 10px;
       max-width: calc(100% - 112px); /* leave 52px gap on each side for corner buttons */
       overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-      background: rgba(0,0,0,.72); color: #fff;
+      background: transparent; color: #fff;
       border-radius: 0 0 8px 8px;   /* flat top, rounds bottom corners only */
       font-size: 12px; font-weight: 600;
       pointer-events: auto; border: 1px solid transparent; cursor: pointer;


### PR DESCRIPTION
### Motivation
- Remove opaque dark backgrounds from the tile overlay controls and name badge so underlying video/preview content shows through. 
- Keep change scoped to CSS only and avoid touching any JavaScript.

### Description
- Updated the CSS in `index.html` to set `.matrix-tile-button` `background` to `transparent` instead of `rgba(0,0,0,.60)`. 
- Updated the CSS in `index.html` to set `.matrix-tile-button:hover` `background` to `transparent` instead of `rgba(0,0,0,.82)`. 
- Updated the CSS in `index.html` to set `.matrix-streamer-name` `background` to `transparent` instead of `rgba(0,0,0,.72)`. 
- Only the `background` properties were changed and no other rules or JavaScript were modified.

### Testing
- Ran a scripted search-and-replace verification (Python) to ensure the original rgba rules were present and replaced, and it completed successfully. 
- Ran `git diff --check` to validate the diff for whitespace/format issues, and it passed. 
- Inspected repository status with `git status --short` to confirm the intended file was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40798993e083328ee28328309d1a54)