### PR TITLE
Restore video grid control backgrounds

### DIFF
--- a/index.html
+++ b/index.html
@@ -272,6 +272,18 @@
     }
     .matrix-quality-btn.timer-pending { color: #ff9500 !important; }
 
+    .matrix-quality-btn::after,
+    .matrix-blacklist::after {
+      content: "";
+      position: absolute;
+      top: 50%; left: 50%;
+      transform: translate(-50%, -50%);
+      width: 26px; height: 26px;
+      background: rgba(0,0,0,.65);
+      border-radius: 6px;
+      z-index: -1;
+    }
+
     .matrix-blacklist {
       top: 0; right: 0;
       width: 52px; height: 52px;
@@ -293,6 +305,7 @@
       max-width: calc(100% - 112px); /* leave 52px gap on each side for corner buttons */
       overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
       background: transparent; color: #fff;
+      text-shadow: 0 1px 4px rgba(0,0,0,.9), 0 0 8px rgba(0,0,0,.7);
       border-radius: 0 0 8px 8px;   /* flat top, rounds bottom corners only */
       font-size: 12px; font-weight: 600;
       pointer-events: auto; border: 1px solid transparent; cursor: pointer;


### PR DESCRIPTION
### Motivation
- Improve visibility and contrast for the clickable controls on each video tile (quality, blacklist, and streamer name) while keeping the streamer label itself transparent.

### Description
- Add a centered dark rounded pseudo-element behind the corner controls via `.matrix-quality-btn::after` and `.matrix-blacklist::after` (26×26px, `rgba(0,0,0,.65)`, centered with `transform`) and add a dark `text-shadow` to `.matrix-streamer-name` in `index.html` to restore readability.

### Testing
- Ran `git diff --check` and a smoke HTML parse using Python's `HTMLParser`, both succeeded, and attempted a Playwright screenshot which failed because Playwright/browser dependencies are not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a408af862988332a79740e20d7a21ae)