### PR TITLE
Constrain matrix tile invisible hit zones to top 20% (15/70/15 layout)

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,9 +256,22 @@
       border: 0; cursor: pointer; z-index: 2;
     }
     .matrix-tile-button:hover { background: transparent; }
-    .matrix-tile-button::before,
+    .matrix-quality-btn::before {
+      content: ""; position: absolute;
+      top: 0; left: 0;
+      width: 15%; height: 20%;
+      background: transparent;
+    }
     .matrix-streamer-name::before {
-      content: ""; position: absolute; inset: -10px;
+      content: ""; position: absolute;
+      top: 0; left: 15%;
+      width: 70%; height: 20%;
+      background: transparent;
+    }
+    .matrix-blacklist::before {
+      content: ""; position: absolute;
+      top: 0; left: 85%;
+      width: 15%; height: 20%;
       background: transparent;
     }
 


### PR DESCRIPTION
### Motivation
- Make the invisible click hit areas at the top of each video tile explicit and predictable so clicks near the visible controls reliably trigger the intended handlers. 
- Use the existing pseudo-element approach so visible icon size, font size, padding, background, border-radius, color and text rendering remain unchanged. 

### Description
- Replaced the shared `inset: -10px` hit-area rule with three explicit pseudo-elements: ` .matrix-quality-btn::before`, `.matrix-streamer-name::before`, and `.matrix-blacklist::before`, each set to `position: absolute`, `background: transparent`, `top: 0`, and `height: 20%` with widths `15%`, `70%`, and `15%` respectively. 
- Left all visible styling intact (no changes to `.matrix-quality-btn`, `.matrix-streamer-name`, `.matrix-blacklist` visible properties), and did not modify the base `.matrix-tile-button` class or any JS event handlers. 

### Testing
- Ran `git diff --check` which passed with no issues. 
- Verified the `index.html` CSS block was updated to include the three new `::before` rules and that no other automated tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4400054ccc8332b458139129251efc)