### PR TITLE
Fix matrix tile hit zones

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,24 +256,17 @@
       border: 0; cursor: pointer; z-index: 2;
     }
     .matrix-tile-button:hover { background: transparent; }
-    .matrix-quality-btn::before {
-      content: ""; position: absolute;
-      top: 0; left: 0;
-      width: 15%; height: 20%;
+    .matrix-hit-zone {
+      position: absolute;
+      top: 0;
+      height: 20%;
       background: transparent;
+      z-index: 3;
+      cursor: pointer;
     }
-    .matrix-streamer-name::before {
-      content: ""; position: absolute;
-      top: 0; left: 15%;
-      width: 70%; height: 20%;
-      background: transparent;
-    }
-    .matrix-blacklist::before {
-      content: ""; position: absolute;
-      top: 0; left: 85%;
-      width: 15%; height: 20%;
-      background: transparent;
-    }
+    .matrix-hit-zone.zone-quality { left: 0; width: 15%; }
+    .matrix-hit-zone.zone-name { left: 15%; width: 70%; }
+    .matrix-hit-zone.zone-pin { left: 85%; width: 15%; }
 
     .matrix-quality-btn {
       top: 0; left: 0;
@@ -1540,7 +1533,20 @@ function openMatrix() {
       nameBadge.title = 'Change stream';
       nameBadge.dataset.role = 'matrix-name-picker';
 
+      const qualityZone = document.createElement('div');
+      qualityZone.className = 'matrix-hit-zone zone-quality';
+      qualityZone.onclick = (e) => { qualityBtn.click(); };
+
+      const nameZone = document.createElement('div');
+      nameZone.className = 'matrix-hit-zone zone-name';
+      nameZone.onclick = (e) => { nameBadge.click(); };
+
+      const pinZone = document.createElement('div');
+      pinZone.className = 'matrix-hit-zone zone-pin';
+      pinZone.onclick = (e) => { xbtn.click(); };
+
       tile.append(qualityBtn, xbtn, nameBadge);
+      tile.append(qualityZone, nameZone, pinZone);
       matrixBody.appendChild(tile);
       matrixTiles.set(index, tile);
 


### PR DESCRIPTION
### Motivation
- The existing `::before` pseudo-elements on the per-tile buttons used percentage sizes that resolve against each button’s small 52px box, so the invisible hit zones were tiny instead of spanning the intended percentages of the tile.
- The goal is to preserve the visible buttons and their logic exactly while providing larger, correctly positioned hit targets that receive clicks before the underlying iframe.

### Description
- Removed the broken `::before` rules on `.matrix-quality-btn`, `.matrix-streamer-name`, and `.matrix-blacklist` and added a new tile-level CSS class ` .matrix-hit-zone` with `z-index: 3` and the requested geometry. 
- Added specific position classes ` .matrix-hit-zone.zone-quality`, ` .matrix-hit-zone.zone-name`, and ` .matrix-hit-zone.zone-pin` to implement the 15% / 70% / 15% top-row layout and `height: 20%` per spec. 
- In `openMatrix()` created three DOM `div`s named `qualityZone`, `nameZone`, and `pinZone`, assigned the new classes, set each zone’s `onclick` to call `qualityBtn.click()`, `nameBadge.click()`, and `xbtn.click()` respectively, and appended them to the tile after the real buttons so they render on top. 
- The visible buttons (`.matrix-quality-btn`, `.matrix-streamer-name`, `.matrix-blacklist`) retain their exact sizes, positions, fonts, padding, appearance, and existing handler logic was not duplicated or changed.

### Testing
- Verified the CSS/JS changes via `rg -n "matrix-quality-btn::before|matrix-streamer-name::before|matrix-blacklist::before|matrix-hit-zone|zone-quality|zone-name|zone-pin" index.html` and confirmed the old pseudo-rules were removed and the new classes exist. 
- Performed a syntax check of the inlined script with `node --check /tmp/twitchmatrix-inline.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4403d808cc833297b5d9f7e784ccc8)