### PR TITLE
Adjust matrix tile click zones and add dead-zone overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,14 +259,23 @@
     .matrix-hit-zone {
       position: absolute;
       top: 0;
-      height: 20%;
+      height: 30%;
       background: transparent;
       z-index: 3;
       cursor: pointer;
     }
-    .matrix-hit-zone.zone-quality { left: 0; width: 15%; }
-    .matrix-hit-zone.zone-name { left: 15%; width: 70%; }
-    .matrix-hit-zone.zone-pin { left: 85%; width: 15%; }
+    .matrix-hit-zone.zone-quality { left: 0; width: 20%; }
+    .matrix-hit-zone.zone-name { left: 20%; width: 60%; }
+    .matrix-hit-zone.zone-pin { left: 80%; width: 20%; }
+    .matrix-dead-zone {
+      position: absolute;
+      top: 30%;
+      left: 0;
+      width: 100%;
+      height: 50%;
+      background: transparent;
+      z-index: 3;
+    }
 
     .matrix-quality-btn {
       top: 0; left: 0;
@@ -1545,8 +1554,12 @@ function openMatrix() {
       pinZone.className = 'matrix-hit-zone zone-pin';
       pinZone.onclick = (e) => { xbtn.click(); };
 
+      const deadZone = document.createElement('div');
+      deadZone.className = 'matrix-dead-zone';
+      deadZone.onclick = (e) => { e.stopPropagation(); e.preventDefault(); };
+
       tile.append(qualityBtn, xbtn, nameBadge);
-      tile.append(qualityZone, nameZone, pinZone);
+      tile.append(qualityZone, nameZone, pinZone, deadZone);
       matrixBody.appendChild(tile);
       matrixTiles.set(index, tile);
 


### PR DESCRIPTION
### Motivation
- Prevent accidental clicks on the embedded Twitch player in the middle of each tile while preserving the existing top hit-zone button behaviors.
- Expand the hit-zone area at the top of each tile so touch/click targets for quality/name/pin controls are more reachable.

### Description
- Update `.matrix-hit-zone` CSS to increase `height` from `20%` to `30%` and change the columns to `zone-quality: 20%`, `zone-name: 60%`, and `zone-pin: 20%`.
- Add a new `.matrix-dead-zone` CSS rule that covers `top: 30%` with `height: 50%` (covering the 30%–80% middle band) and is transparent.
- In `openMatrix`, create a `deadZone` element with `className = 'matrix-dead-zone'` and `onclick` that calls `e.stopPropagation()` and `e.preventDefault()`, and append it alongside the existing `qualityZone`, `nameZone`, and `pinZone` elements.
- Preserve all existing hit-zone delegation logic (`qualityZone`, `nameZone`, `pinZone` and their `onclick` calls to `qualityBtn.click()`, `nameBadge.click()`, and `xbtn.click()`) without other modifications.

### Testing
- Ran `git diff --check` and it completed with no errors (exit code 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4406796f0883329d039e3057c1fc07)