### PR TITLE
Stop matrix hit zone click propagation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1544,15 +1544,15 @@ function openMatrix() {
 
       const qualityZone = document.createElement('div');
       qualityZone.className = 'matrix-hit-zone zone-quality';
-      qualityZone.onclick = (e) => { qualityBtn.click(); };
+      qualityZone.onclick = (e) => { e.stopPropagation(); qualityBtn.click(); };
 
       const nameZone = document.createElement('div');
       nameZone.className = 'matrix-hit-zone zone-name';
-      nameZone.onclick = (e) => { nameBadge.click(); };
+      nameZone.onclick = (e) => { e.stopPropagation(); nameBadge.click(); };
 
       const pinZone = document.createElement('div');
       pinZone.className = 'matrix-hit-zone zone-pin';
-      pinZone.onclick = (e) => { xbtn.click(); };
+      pinZone.onclick = (e) => { e.stopPropagation(); xbtn.click(); };
 
       const deadZone = document.createElement('div');
       deadZone.className = 'matrix-dead-zone';


### PR DESCRIPTION
### Motivation
- Prevent hit-zone clicks in the `openMatrix` UI from bubbling up to `document` and immediately closing newly opened dropdowns. 
- Ensure the synthetic `.click()` calls on the underlying controls can open dropdowns without being consumed by the original outer click listener.

### Description
- In `index.html` inside `openMatrix`, updated the three hit-zone handlers so each handler calls `e.stopPropagation()` before triggering the synthetic click: `qualityZone.onclick`, `nameZone.onclick`, and `pinZone.onclick`.
- No other logic or files were changed.

### Testing
- Ran `git diff --check` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a442ed4a84883328b07a52a731f1b98)