### PR TITLE
Rank columns by actual rendered tile area and prefer width-fill within tolerance

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,8 +234,9 @@
       overflow:auto;
       padding:2px;
       display:grid;
-      gap:1px;
-      justify-content:center;
+      column-gap:1px;
+      row-gap:1px;
+      justify-content:start;
       align-content:start;
       background:#000;
     }
@@ -1410,38 +1411,43 @@ async function refreshDisplayedMatrixStreams() {
 }
 
 /* --- Layout --- */
+const WIDTH_FILL_AREA_TOLERANCE = 0.02;
+
 function optimalCols(n, W, H, gap) {
-  let best = {cols: 1, area: -1, overflow: Infinity};
+  let best = null;
+  let bestWidthBound = null;
+
   for (let cols = 1; cols <= n; cols++) {
     const rows = Math.ceil(n / cols);
     const totalGapW = gap * (cols - 1);
     const totalGapH = gap * (rows - 1);
-    const tileW = Math.max(0, (W - totalGapW) / cols);
-    const tileH = tileW * 9 / 16;
-    const gridH = rows * tileH + totalGapH;
-    const area = tileW * tileH * (n / (rows * cols));
-    const overflow = Math.max(0, gridH - H);
-    const fits = overflow <= H * 0.05;
-    if (fits && (area > best.area || (area === best.area && cols > best.cols))) {
-      best = {cols, area, overflow};
+
+    const tileWWidthOnly = Math.max(0, (W - totalGapW) / cols);
+    const tileHWidthOnly = tileWWidthOnly * 9 / 16;
+    const areaWidthOnly = tileWWidthOnly * tileHWidthOnly * (n / (rows * cols));
+
+    const tileWfromW = Math.floor(tileWWidthOnly);
+    const tileHfromH = Math.floor(Math.max(0, (H - totalGapH) / rows));
+    const tileWfromH = Math.floor(tileHfromH * 16 / 9);
+    const tileWFinal = Math.min(tileWfromW, tileWfromH);
+    const tileHFinal = tileWFinal * 9 / 16;
+    const areaFinal = tileWFinal * tileHFinal * (n / (rows * cols));
+    const candidate = { cols, areaFinal, areaWidthOnly, widthBound: tileWfromW <= tileWfromH };
+
+    if (!best || areaFinal > best.areaFinal || (areaFinal === best.areaFinal && cols > best.cols)) {
+      best = candidate;
+    }
+
+    if (candidate.widthBound && (!bestWidthBound || areaFinal > bestWidthBound.areaFinal || (areaFinal === bestWidthBound.areaFinal && cols > bestWidthBound.cols))) {
+      bestWidthBound = candidate;
     }
   }
-  if (best.area >= 0) return best.cols;
-  let minOverflow = Infinity, bestCols = 1, bestArea = -1;
-  for (let cols = 1; cols <= n; cols++) {
-    const rows = Math.ceil(n / cols);
-    const totalGapW = gap * (cols - 1);
-    const totalGapH = gap * (rows - 1);
-    const tileW = Math.max(0, (W - totalGapW) / cols);
-    const tileH = tileW * 9 / 16;
-    const gridH = rows * tileH + totalGapH;
-    const overflow = Math.max(0, gridH - H);
-    const area = tileW * tileH * (n / (rows * cols));
-    if (overflow < minOverflow || (overflow === minOverflow && area > bestArea)) {
-      minOverflow = overflow; bestArea = area; bestCols = cols;
-    }
+
+  if (bestWidthBound && bestWidthBound.areaFinal >= best.areaFinal * (1 - WIDTH_FILL_AREA_TOLERANCE)) {
+    return bestWidthBound.cols;
   }
-  return bestCols;
+
+  return best.cols;
 }
 
 function applyMatrixLayout() {
@@ -1450,13 +1456,20 @@ function applyMatrixLayout() {
   Array.from(tiles).forEach(t => { t.style.gridColumn = ''; t.style.gridRow = ''; });
   matrixBody.style.gridTemplateColumns = '';
   matrixBody.style.gridTemplateRows = '';
+  matrixBody.style.paddingLeft = '';
+  matrixBody.style.paddingRight = '';
   const gap = 1;
+  const matrixStyle = getComputedStyle(matrixBody);
+  const basePaddingLeft = parseFloat(matrixStyle.paddingLeft) || 0;
+  const basePaddingRight = parseFloat(matrixStyle.paddingRight) || 0;
+  const basePaddingTop = parseFloat(matrixStyle.paddingTop) || 0;
+  const basePaddingBottom = parseFloat(matrixStyle.paddingBottom) || 0;
   const rect = matrixBody.getBoundingClientRect();
-  let width = rect.width;
-  let height = rect.height;
+  let width = Math.max(0, rect.width - basePaddingLeft - basePaddingRight);
+  let height = Math.max(0, rect.height - basePaddingTop - basePaddingBottom);
   if (!width || !height) {
-    width = window.innerWidth;
-    height = Math.max(0, window.innerHeight - (matrixHeader.offsetHeight || 42));
+    width = Math.max(0, window.innerWidth - basePaddingLeft - basePaddingRight);
+    height = Math.max(0, window.innerHeight - (matrixHeader.offsetHeight || 42) - basePaddingTop - basePaddingBottom);
   }
 
   const cols = optimalCols(n, width, height, gap);
@@ -1473,7 +1486,12 @@ function applyMatrixLayout() {
   // Use whichever constraint is tighter
   const tileW = Math.min(tileWfromW, tileWfromH);
   const tileH = Math.floor(tileW * 9 / 16);
-  matrixBody.style.gap = `${gap}px`;
+  const gridW = cols * tileW + gap * (cols - 1);
+  const horizontalMargin = Math.max(0, Math.floor((width - gridW) / 2));
+  matrixBody.style.columnGap = `${gap}px`;
+  matrixBody.style.rowGap = `${gap}px`;
+  matrixBody.style.paddingLeft = `${basePaddingLeft + horizontalMargin}px`;
+  matrixBody.style.paddingRight = `${basePaddingRight + Math.max(0, width - gridW - horizontalMargin)}px`;
   matrixBody.style.gridTemplateColumns = `repeat(${cols}, ${tileW}px)`;
   matrixBody.style.gridTemplateRows = `repeat(${rows}, ${tileH}px)`;
   Array.from(matrixBody.children).forEach(t => {


### PR DESCRIPTION
### Motivation
- The previous `optimalCols()` used a width-only area approximation that could differ from what `applyMatrixLayout()` actually renders, producing unused horizontal margin when height became the binding constraint. 
- The goal is to have `optimalCols()` predict the final rendered tile area (matching `applyMatrixLayout()` sizing) while still preferring full-width layouts when the area loss is negligible.

### Description
- Add a named constant `WIDTH_FILL_AREA_TOLERANCE = 0.02` to make the width-fill override threshold easy to tune. 
- Rewrite `optimalCols(n, W, H, gap)` to compute both the width-only estimate and the actual final tile size used by the renderer (`tileWFinal = min(tileWfromW, tileWfromH)`) and rank candidates by `areaFinal`; also track width-bound candidates and let a width-bound candidate override the area winner only if its `areaFinal` is within `1 - WIDTH_FILL_AREA_TOLERANCE` of the best area. 
- Keep gaps fixed at `1px` by switching CSS to explicit `column-gap`/`row-gap` and change grid `justify-content` to `start`, then center leftover horizontal space in `applyMatrixLayout()` by computing and applying `paddingLeft`/`paddingRight` rather than using grid justification so the gap remains constant. 
- Preserve the existing tile aspect ratio (`16:9`) and do not change Twitch player or refresh/quality-timer logic.

### Testing
- Ran `node --check /tmp/twitchmatrix-script.js` to verify the inlined script parses and it succeeded. 
- Ran `git diff --check` to validate whitespace and diff checks and it returned no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a77d00ab0833287e3526e815c67a3)