### PR TITLE
Scroll page before opening matrix

### DIFF
--- a/index.html
+++ b/index.html
@@ -1505,6 +1505,13 @@ function applyMatrixLayout() {
    First call: creates Twitch.Player instances and DOM tiles.
    Subsequent calls (refresh): updates existing players via setChannel.
    Players are NEVER destroyed. --------------------------------------- */
+const MATRIX_OPEN_SCROLL_OFFSET_PX = 20;
+
+function scrollMainPageBeforeMatrixOpen() {
+  if (window.scrollY <= 0) return;
+  window.scrollBy({ top: -MATRIX_OPEN_SCROLL_OFFSET_PX, left: 0, behavior: 'auto' });
+}
+
 function openMatrix() {
   if (!lastLive.length) return;
 
@@ -1512,6 +1519,8 @@ function openMatrix() {
     console.error('No hostname — cannot embed Twitch');
     return;
   }
+
+  scrollMainPageBeforeMatrixOpen();
 
   matrixBackdrop.style.display = 'flex';
   document.body.style.overflow = 'hidden';


### PR DESCRIPTION
### Motivation
- Prevent the page from visually jumping when the embedded matrix overlay is opened by nudging the main page up a small amount before the video grid appears.

### Description
- Add a `MATRIX_OPEN_SCROLL_OFFSET_PX = 20` constant and a helper `scrollMainPageBeforeMatrixOpen()` that scrolls the page up by that offset when appropriate.
- Invoke `scrollMainPageBeforeMatrixOpen()` at the start of `openMatrix()` so the main page scrolls before `matrixBackdrop` is shown and players are initialized.

### Testing
- Ran `git diff --check`, which reported no whitespace/errors related to the change and succeeded. 
- Ran `node --check index.html` to attempt a syntax check, but Node cannot check `.html` files in this environment and reported an unknown `.html` extension (not a failure of the change itself).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ffb8784188332b38c352b1704403b)