### PR TITLE
Await and improve pre-open scroll for matrix overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -1505,14 +1505,22 @@ function applyMatrixLayout() {
    First call: creates Twitch.Player instances and DOM tiles.
    Subsequent calls (refresh): updates existing players via setChannel.
    Players are NEVER destroyed. --------------------------------------- */
-const MATRIX_OPEN_SCROLL_OFFSET_PX = 20;
+const MATRIX_OPEN_SCROLL_OFFSET_PX = 80;
 
 function scrollMainPageBeforeMatrixOpen() {
-  if (window.scrollY <= 0) return;
-  window.scrollBy({ top: -MATRIX_OPEN_SCROLL_OFFSET_PX, left: 0, behavior: 'auto' });
+  const scrollingEl = document.scrollingElement || document.documentElement || document.body;
+  const currentTop = Math.max(window.scrollY || 0, scrollingEl?.scrollTop || 0);
+  if (currentTop <= 0) return Promise.resolve();
+
+  const nextTop = Math.max(0, currentTop - MATRIX_OPEN_SCROLL_OFFSET_PX);
+  if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
+  if (scrollingEl) scrollingEl.scrollTop = nextTop;
+  window.scrollTo({ top: nextTop, left: 0, behavior: 'auto' });
+
+  return new Promise(resolve => requestAnimationFrame(resolve));
 }
 
-function openMatrix() {
+async function openMatrix() {
   if (!lastLive.length) return;
 
   if (!STATIC_HOST) {
@@ -1520,7 +1528,7 @@ function openMatrix() {
     return;
   }
 
-  scrollMainPageBeforeMatrixOpen();
+  await scrollMainPageBeforeMatrixOpen();
 
   matrixBackdrop.style.display = 'flex';
   document.body.style.overflow = 'hidden';


### PR DESCRIPTION
### Motivation
- Ensure the page actually scrolls before the fixed matrix overlay is shown so the overlay doesn’t capture scroll position or hide content unexpectedly. 
- Prevent focus snapping when the matrix is opened by blurring the active element before moving the page.
- Make the pre-open motion large enough to be noticeable on longer pages.

### Description
- Replace the simple `window.scrollBy` with a new `scrollMainPageBeforeMatrixOpen` implementation that targets `document.scrollingElement`, computes the current scroll top, blurs `document.activeElement`, sets `scrollTop` and calls `window.scrollTo`, and returns a promise resolved on the next animation frame. 
- Increase the offset `MATRIX_OPEN_SCROLL_OFFSET_PX` from `20` to `80` to make the movement more obvious. 
- Change `openMatrix` to `async` and `await` `scrollMainPageBeforeMatrixOpen()` so the backdrop is shown only after the scroll is applied. 
- All edits are made in `index.html` and committed to the branch.

### Testing
- Ran `node --check /tmp/twitchmatrix-inline.js` to validate the inlined script syntax and it succeeded. 
- Ran `git diff --check` for whitespace/patch issues and it succeeded. 
- The change was committed locally as part of the update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a500030550c8332beaaccad3b373ac8)