### PR TITLE
Revert matrix pre-open scrolling changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1505,30 +1505,13 @@ function applyMatrixLayout() {
    First call: creates Twitch.Player instances and DOM tiles.
    Subsequent calls (refresh): updates existing players via setChannel.
    Players are NEVER destroyed. --------------------------------------- */
-const MATRIX_OPEN_SCROLL_OFFSET_PX = 80;
-
-function scrollMainPageBeforeMatrixOpen() {
-  const scrollingEl = document.scrollingElement || document.documentElement || document.body;
-  const currentTop = Math.max(window.scrollY || 0, scrollingEl?.scrollTop || 0);
-  if (currentTop <= 0) return Promise.resolve();
-
-  const nextTop = Math.max(0, currentTop - MATRIX_OPEN_SCROLL_OFFSET_PX);
-  if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
-  if (scrollingEl) scrollingEl.scrollTop = nextTop;
-  window.scrollTo({ top: nextTop, left: 0, behavior: 'auto' });
-
-  return new Promise(resolve => requestAnimationFrame(resolve));
-}
-
-async function openMatrix() {
+function openMatrix() {
   if (!lastLive.length) return;
 
   if (!STATIC_HOST) {
     console.error('No hostname — cannot embed Twitch');
     return;
   }
-
-  await scrollMainPageBeforeMatrixOpen();
 
   matrixBackdrop.style.display = 'flex';
   document.body.style.overflow = 'hidden';


### PR DESCRIPTION
### Motivation
- Two recent changes added a pre-open page scrolling helper to adjust page position before showing the matrix but did not resolve the issue and introduced regressions.
- The goal is to restore the previous synchronous `openMatrix` behavior and remove the scrolling helper so the matrix open flow matches the prior UX.

### Description
- Removed the `MATRIX_OPEN_SCROLL_OFFSET_PX` constant and the `scrollMainPageBeforeMatrixOpen` helper from `index.html`.
- Restored `openMatrix` to a synchronous function by removing `async` and the `await scrollMainPageBeforeMatrixOpen()` call.
- Restored the original matrix open flow so the backdrop and player initialization run without pre-open scrolling logic.

### Testing
- Ran `git diff --exit-code HEAD~4 -- index.html` which succeeded and showed only the intended reversion diff.
- Ran a `python3` assertion script that confirmed `scrollMainPageBeforeMatrixOpen` and `MATRIX_OPEN_SCROLL_OFFSET_PX` are absent and `openMatrix` is synchronous, and the assertion passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a500543cb108332980697a5f49367ef)