### PR TITLE
Add IRL discovery tier to quick retrieve

### DIFF
--- a/index.html
+++ b/index.html
@@ -737,6 +737,7 @@ async function fetchCategoryTop(catName, limit){
       const data = await gqlSingle({ operationName:"CategoryTop", query:categoryTopQuery, variables:{ name:nm, limit } });
       const edges = data?.[0]?.data?.game?.streams?.edges || [];
       const logins = edges.map(e=>e?.node?.broadcaster?.login).filter(Boolean);
+      logins.viewersByLogin = new Map(edges.map(e => [e?.node?.broadcaster?.login, e?.node?.viewersCount]).filter(([login]) => login));
       if(logins.length) return logins;
     }catch(e){ /* try next */ }
   }
@@ -792,6 +793,14 @@ async function retrieveAll(full = false){
           renderTierOnlineSnapshot();
         }catch(e){ console.error("Batch error", e); markError(chunk); }
         finally{ setWorking(chunk, false); }
+      }
+      if (!full) {
+        const irlNames = await fetchCategoryTop("IRL", 7);
+        replaceTier(4, irlNames);
+        irlNames.forEach(name => {
+          resultsCache.set(name, { isLive: true, category: "IRL", viewers: irlNames.viewersByLogin?.get(name) ?? null, title: null });
+          paintLabel(name, resultsCache.get(name));
+        });
       }
       statusEl.textContent = "Retrieve complete. Click Generate to pick from cache.";
       renderTierOnlineSnapshot();
@@ -1353,7 +1362,7 @@ async function openMatrixTilePicker(tile) {
 function getOnlineFeedNames() {
   const hidden = new Set(lastLive || []);
   const names = [];
-  for(let i=0; i<3; i++){
+  for(const i of [0, 1, 2, 4]){
     for(const name of (tiers[i] || [])){
       const r = resultsCache.get(name);
       if(!r?.isLive || hidden.has(name)) continue;


### PR DESCRIPTION
### Motivation
- Add a lightweight, quick-discovery source for the picker by exposing the top-7 live IRL streams as a layered discovery tier (UI "Tier 5 IRL") without changing the full retrieve path or tier limits.

### Description
- In `retrieveAll(full)` quick path (`full === false`) call `fetchCategoryTop("IRL", 7)`, `replaceTier(4, names)`, and populate `resultsCache` for each returned login with `{ isLive: true, category: "IRL", viewers: <from GraphQL>, title: null }` and call `paintLabel` so the UI reflects the cached entries.
- Extend `fetchCategoryTop` to attach a `viewersByLogin` map to the returned login list so the IRL quick-cache can record viewer counts from the GraphQL response.
- Update `getOnlineFeedNames()` to include tier index 4 in the quick-pick feed iteration (iterate over indices 0, 1, 2, and 4) while continuing to skip the other tiers.
- Keep all changes small and localized: full retrieve path, `getTierOnlineSnapshot()`, and tier-limit pills remain unchanged.

### Testing
- Attempted `node --check index.html` failed as expected due to checking an `.html` file directly and not a standalone JS file, so inline scripts were extracted first, which is the correct approach for validation; this failure is informational and expected.
- Extracted inline scripts to `/tmp/twitchmatrix-scripts.js` and ran `node --check /tmp/twitchmatrix-scripts.js`, which completed successfully.
- Ran repository consistency checks (`git diff --check`) which reported no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a551370255c83328e0d67247291d301)