### PR TITLE
Stack matrix header above grid and reduce header height

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,21 +152,22 @@
     }
     .matrix-modal {
       position: absolute; inset: 0;
-      display: block;
+      display: flex;
+      flex-direction: column;
       background: #000;
     }
     .matrix-header {
-      position:absolute;
-      top:0; left:0; right:0;
+      position:relative;
+      flex:0 0 auto;
       display:flex;
       align-items:center;
       justify-content:flex-start;
       gap:8px;
-      padding:10px 12px;
+      padding:1px 12px;
       background:rgba(10,10,10,.82);
       border-bottom:1px solid rgba(17,17,17,.82);
       color:#ddd;
-      min-height:42px;
+      min-height:0;
       z-index:10;
     }
     .matrix-close { cursor:pointer; font-size:20px; line-height:1; background:none; border:0; color:#ddd; margin-left:auto; }
@@ -232,8 +233,9 @@
       justify-content:center;
     }
     .matrix-body {
-      position:absolute;
-      inset:0;
+      position:relative;
+      flex:1 1 auto;
+      min-height:0;
       overflow:auto;
       padding:0;
       display:grid;


### PR DESCRIPTION
### Motivation
- The matrix overlay header was absolutely positioned and overlapped the video grid, and the overlay had a small gap from the top of the browser; the UI should stack header above the grid and sit flush to the top.
- The header was taller than necessary, so vertical padding should be reduced to tighten the layout.

### Description
- Updated CSS in `index.html` to make `.matrix-modal` a column flex container (`display: flex; flex-direction: column;`) so children stack vertically.
- Converted `.matrix-header` from absolute positioning to in-flow layout (`position: relative; flex: 0 0 auto;`) and reduced vertical padding to `1px 12px` and `min-height: 0` to shorten the header.
- Changed `.matrix-body` from absolute inset layout to a flexible content region (`position: relative; flex: 1 1 auto; min-height: 0`) so the video grid consumes the remaining modal height below the header.
- Kept existing grid/tile rules intact while ensuring the overlay no longer overlaps the grid and is flush against the browser edges.

### Testing
- Launched a local server with `python3 -m http.server 8000` to exercise the static page, which started successfully.
- Ran an automated Python assertion script that verified the new CSS fragments (`display: flex; flex-direction: column;`, `padding:1px 12px;`, and `flex:1 1 auto;`) are present, and the assertions passed.
- Ran `git diff --check` to validate whitespace/format issues, which produced no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a551e68c0148332bfbd58be46ad34e0)