### PR TITLE
Sync matrix header margins and set 3px vertical padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,8 +163,10 @@
       align-items:center;
       justify-content:flex-start;
       gap:8px;
-      padding:1px 12px;
-      background:rgba(10,10,10,.82);
+      --matrix-grid-margin-left:0px;
+      --matrix-grid-margin-right:0px;
+      padding:3px calc(12px + var(--matrix-grid-margin-right)) 3px calc(12px + var(--matrix-grid-margin-left));
+      background:#000;
       border-bottom:1px solid rgba(17,17,17,.82);
       color:#ddd;
       min-height:0;
@@ -1467,6 +1469,11 @@ function optimalCols(n, W, H, gap) {
   return best.cols;
 }
 
+function syncMatrixHeaderMargins(left, right) {
+  matrixHeader.style.setProperty('--matrix-grid-margin-left', `${Math.max(0, Math.round(left))}px`);
+  matrixHeader.style.setProperty('--matrix-grid-margin-right', `${Math.max(0, Math.round(right))}px`);
+}
+
 function applyMatrixLayout() {
   const n = Math.max(1, lastLive.length);
   const tiles = matrixBody.children;
@@ -1505,10 +1512,12 @@ function applyMatrixLayout() {
   const tileH = Math.floor(tileW * 9 / 16);
   const gridW = cols * tileW + gap * (cols - 1);
   const horizontalMargin = Math.max(0, Math.floor((width - gridW) / 2));
+  const trailingMargin = Math.max(0, width - gridW - horizontalMargin);
+  syncMatrixHeaderMargins(basePaddingLeft + horizontalMargin, basePaddingRight + trailingMargin);
   matrixBody.style.columnGap = `${gap}px`;
   matrixBody.style.rowGap = `${gap}px`;
   matrixBody.style.paddingLeft = `${basePaddingLeft + horizontalMargin}px`;
-  matrixBody.style.paddingRight = `${basePaddingRight + Math.max(0, width - gridW - horizontalMargin)}px`;
+  matrixBody.style.paddingRight = `${basePaddingRight + trailingMargin}px`;
   matrixBody.style.gridTemplateColumns = `repeat(${cols}, ${tileW}px)`;
   matrixBody.style.gridTemplateRows = `repeat(${rows}, ${tileH}px)`;
   Array.from(matrixBody.children).forEach(t => {


### PR DESCRIPTION
### Motivation
- Prevent the page title from showing through the top of the matrix overlay and make the header spacing match the centered video grid so header controls align with the grid width.
- Reduce the header top/bottom spacing to `3px` to eliminate the small gap between the browser top and the header.

### Description
- Updated `.matrix-header` to use CSS variables `--matrix-grid-margin-left` and `--matrix-grid-margin-right`, set vertical padding to `3px`, and make the header background fully opaque (`#000`).
- Added `syncMatrixHeaderMargins(left, right)` which writes the computed margins into the header CSS variables.
- Call `syncMatrixHeaderMargins` from `applyMatrixLayout()` after computing the centered grid margins and changed the layout math to compute a `trailingMargin` used both for the header variables and `matrixBody` padding.
- All changes are in `index.html` and keep the existing grid sizing logic while ensuring header horizontal padding follows the grid.

### Testing
- Ran `git diff --check` which reported no problems and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55207502f4833292477ed549de90de)