### PR TITLE
Fix matrix overlay sizing by using explicit positioning and `100dvh`

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,11 @@
 
     /* Matrix overlay */
     .matrix-backdrop {
-      position: fixed; inset: 0;
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100vw;
+      height: 100dvh;
       background: #000;
       display: none;
       align-items: stretch; justify-content: stretch;
@@ -983,7 +987,6 @@ let matrixRefreshInProgress = false;
 let matrixCountdownSeconds = 0;
 let matrixResizeHandler = null;
 const qualityTimers = new Map();
-
 /* --- Player helpers --- */
 
 function applyInitialMatrixQuality(player) {


### PR DESCRIPTION
### Motivation
- Prevent the matrix overlay from being clipped or sized incorrectly on some viewports (notably mobile browsers) where `inset: 0` and `100vh` can behave inconsistently. 

### Description
- Replace the `.matrix-backdrop` shorthand `inset: 0` with explicit positioning and sizing using `top: 0`, `left: 0`, `width: 100vw`, and `height: 100dvh` to ensure full-viewport coverage.
- Minor whitespace/formatting cleanup in the surrounding JavaScript (removed an extra blank line after `qualityTimers` declaration).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a552180c43083328c82325242b087e2)