### PR TITLE
Handle visual viewport matrix resize

### DIFF
--- a/index.html
+++ b/index.html
@@ -1731,9 +1731,17 @@ function openMatrix() {
       observer.disconnect();
       applyMatrixLayout();
 
-      if (matrixResizeHandler) window.removeEventListener('resize', matrixResizeHandler);
+      if (matrixResizeHandler) {
+        window.removeEventListener('resize', matrixResizeHandler);
+        if (window.visualViewport) {
+          window.visualViewport.removeEventListener('resize', matrixResizeHandler);
+        }
+      }
       matrixResizeHandler = applyMatrixLayout;
       window.addEventListener('resize', matrixResizeHandler, { passive: true });
+      if (window.visualViewport) {
+        window.visualViewport.addEventListener('resize', matrixResizeHandler, { passive: true });
+      }
     }
   });
   ro.observe(matrixBody);


### PR DESCRIPTION
### Motivation
- Ensure the matrix layout responds to `visualViewport` resize events (e.g. virtual keyboard / viewport changes) and avoid duplicate resize callbacks when re-registering the handler.

### Description
- Add removal and registration of a `window.visualViewport` `'resize'` listener alongside the existing `window` listener and guard both operations by checking `matrixResizeHandler` and `window.visualViewport` support.

### Testing
- Ran `git diff --check` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5529c27eb883329186e181a91e28ee)