### PR TITLE
Revert visual viewport matrix resize

### DIFF
--- a/index.html
+++ b/index.html
@@ -1714,17 +1714,9 @@ function openMatrix() {
       observer.disconnect();
       applyMatrixLayout();
 
-      if (matrixResizeHandler) {
-        window.removeEventListener('resize', matrixResizeHandler);
-        if (window.visualViewport) {
-          window.visualViewport.removeEventListener('resize', matrixResizeHandler);
-        }
-      }
+      if (matrixResizeHandler) window.removeEventListener('resize', matrixResizeHandler);
       matrixResizeHandler = applyMatrixLayout;
       window.addEventListener('resize', matrixResizeHandler, { passive: true });
-      if (window.visualViewport) {
-        window.visualViewport.addEventListener('resize', matrixResizeHandler, { passive: true });
-      }
     }
   });
   ro.observe(matrixBody);


### PR DESCRIPTION
### Motivation
- Undo a recent change that registered `visualViewport` resize listeners and altered the matrix resize handling to restore the prior, simpler window/element resize behavior.

### Description
- Removed registration/removal of `window.visualViewport` resize handlers and reverted to using only the standard `window` resize handler for `applyMatrixLayout` within the matrix `ResizeObserver` path in `index.html`.
- Updated the `ResizeObserver` callback to disconnect, call `applyMatrixLayout`, and then install a single `window` resize listener via the existing `matrixResizeHandler` reference.

### Testing
- Ran `git status --short` which completed successfully.
- Inspected the created HEAD with `git show --stat --oneline HEAD` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a552c4789448332ad30b2b4ec8a3c52)