### PR TITLE
Use constants for category fetch/display limits and filter duplicate IRL results

### DIFF
--- a/index.html
+++ b/index.html
@@ -730,6 +730,9 @@ async function gqlSingle(op){
   if(!res.ok) throw new Error("HTTP "+res.status);
   return res.json();
 }
+const CATEGORY_FETCH_LIMIT = 20;
+const CATEGORY_DISPLAY_LIMIT = 7;
+
 async function fetchCategoryTop(catName, limit){
   const tryNames = catName==="IRL" ? ["IRL","Travel & Outdoors"] : [catName];
   for(const nm of tryNames){
@@ -758,10 +761,10 @@ async function retrieveAll(full = false){
   retrievePromise = (async () => {
     setRetrievePending(true);
     try{
-      statusEl.textContent = "Retrieving categories (top 20) and statuses…";
+      statusEl.textContent = `Retrieving categories (top ${CATEGORY_FETCH_LIMIT}) and statuses…`;
       pickedEl.textContent = "";
       if (full) {
-        let [irl, jc] = await Promise.all([ fetchCategoryTop("IRL", 20), fetchCategoryTop("Just Chatting", 20) ]);
+        let [irl, jc] = await Promise.all([ fetchCategoryTop("IRL", CATEGORY_FETCH_LIMIT), fetchCategoryTop("Just Chatting", CATEGORY_FETCH_LIMIT) ]);
         const existing = new Set([ ...tier1, ...tier2, ...tier3, ...tier4 ]);
         irl = irl.filter(n => !existing.has(n));
         irl.forEach(n => existing.add(n));
@@ -794,7 +797,10 @@ async function retrieveAll(full = false){
         finally{ setWorking(chunk, false); }
       }
       if (!full) {
-        const irlNames = await fetchCategoryTop("IRL", 7);
+        const existingNames = new Set([ ...tier1, ...tier2, ...tier3 ]);
+        const irlNames = (await fetchCategoryTop("IRL", CATEGORY_FETCH_LIMIT))
+          .filter(n => !existingNames.has(n))
+          .slice(0, CATEGORY_DISPLAY_LIMIT);
         replaceTier(4, irlNames);
         if (irlNames.length) {
           const fetched = await fetchBatch(irlNames);


### PR DESCRIPTION
### Motivation

- Make category fetch and display limits configurable via named constants instead of hardcoded literals to simplify tuning.
- Avoid showing streamers in the IRL display that are already present in higher-priority tiers by fetching a larger set and filtering duplicates.

### Description

- Added `CATEGORY_FETCH_LIMIT` and `CATEGORY_DISPLAY_LIMIT` constants and replaced hardcoded `20`/`7` usages with these values in status text and `fetchCategoryTop` calls.
- When doing a non-full retrieve, fetch up to `CATEGORY_FETCH_LIMIT` IRL streamers, filter out names already present in tiers, and then slice to `CATEGORY_DISPLAY_LIMIT` before displaying.
- Updated status messaging to reflect the `CATEGORY_FETCH_LIMIT` constant in the retrieve progress text.
- Preserves existing caching and painting behavior by still populating `resultsCache` and calling `paintLabel` for the selected display set.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a554694cd5c8332afd6a4d937d4f33a)