### PR TITLE
Fix partial tier 5 refill exclusions

### DIFF
--- a/index.html
+++ b/index.html
@@ -797,9 +797,9 @@ async function retrieveAll(full = false){
         finally{ setWorking(chunk, false); }
       }
       if (!full) {
-        const existingNames = new Set([ ...tier1, ...tier2, ...tier3 ]);
+        const existingNames = new Set([ ...tier1, ...tier2, ...tier3, ...getDisplayedMatrixStreams() ].map(n => String(n).toLowerCase()));
         const irlNames = (await fetchCategoryTop("IRL", CATEGORY_FETCH_LIMIT))
-          .filter(n => !existingNames.has(n))
+          .filter(n => !existingNames.has(String(n).toLowerCase()))
           .slice(0, CATEGORY_DISPLAY_LIMIT);
         replaceTier(4, irlNames);
         if (irlNames.length) {


### PR DESCRIPTION
### Motivation
- Ensure the partial `retrieveAll(false)` flow fetches the full category batch, excludes streamers already shown on the matrix, then slices to the display limit so live matrix tiles don't reduce the visible Tier 5 candidates; comparisons should be case-insensitive to match Twitch logins reliably.

### Description
- In `index.html` inside `retrieveAll(full = false)` include `getDisplayedMatrixStreams()` in the `existingNames` set and normalize entries with `String(...).toLowerCase()` so exclusions are case-insensitive.
- Update the filter on the fetched IRL category results to compare lower-cased names before applying `.slice(0, CATEGORY_DISPLAY_LIMIT)` so the code fetches up to `CATEGORY_FETCH_LIMIT`, filters, then takes `CATEGORY_DISPLAY_LIMIT`.

### Testing
- Ran `git diff --check` to validate the change and check for whitespace/errors, and it completed without issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a554bb4ba688332b6b05b8732931f9f)