### PR TITLE
Fix matrix modal/body sizing to prevent overflow and enable proper scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,6 +152,7 @@
     }
     .matrix-modal {
       position: absolute; inset: 0;
+      width: 100vw; height: 100vh;
       display: flex; flex-direction: column;
       background: #000;
     }
@@ -230,7 +231,11 @@
       justify-content:center;
     }
     .matrix-body {
-      flex:1;
+      flex:1 1 auto;
+      min-height:0;
+      width:100%;
+      height:100%;
+      box-sizing:border-box;
       overflow:auto;
       padding:2px;
       display:grid;


### PR DESCRIPTION
### Motivation
- Ensure the matrix overlay fills the viewport and its `.matrix-body` can shrink/scroll correctly to avoid overflow and layout clipping in the modal.

### Description
- Add `width: 100vw; height: 100vh;` to `.matrix-modal` and change `.matrix-body` to `flex: 1 1 auto; min-height: 0; width: 100%; height: 100%; box-sizing: border-box;` to allow proper flex shrinking and full-viewport sizing.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a555b762464833291b00b8c1b7bc277)