### PR TITLE
Revert matrix popup container fill

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,7 +152,6 @@
     }
     .matrix-modal {
       position: absolute; inset: 0;
-      width: 100vw; height: 100vh;
       display: flex; flex-direction: column;
       background: #000;
     }
@@ -231,11 +230,7 @@
       justify-content:center;
     }
     .matrix-body {
-      flex:1 1 auto;
-      min-height:0;
-      width:100%;
-      height:100%;
-      box-sizing:border-box;
+      flex:1;
       overflow:auto;
       padding:2px;
       display:grid;


### PR DESCRIPTION
### Motivation
- Revert the recent attempt to force the matrix overlay to fill the viewport because the change still left a visible ~10px gap above the matrix header that revealed the settings page underneath, so restore the previous baseline to allow addressing the real overlay/viewport cause.

### Description
- Remove the explicit `width: 100vw; height: 100vh;` on `.matrix-modal` and restore `.matrix-body` to `flex: 1` by undoing the previously added `flex:1 1 auto`, `min-height`, `width`, `height`, and `box-sizing` rules so the layout returns to prior behavior.

### Testing
- Executed the revert and validated repository state with `git show --check --stat HEAD` which succeeded.  
- Verified `git status --short` and recent `git log` commands completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a555fd0e4108332a575f46d2bf3750a)