### PR TITLE
Revert matrix modal viewport sync fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,12 +144,8 @@
 
     /* Matrix overlay */
     .matrix-backdrop {
-      position: fixed;
-      top: var(--matrix-viewport-top, 0px);
-      left: var(--matrix-viewport-left, 0px);
-      width: var(--matrix-viewport-width, 100vw);
-      height: var(--matrix-viewport-height, 100vh);
-      background: #000;
+      position: fixed; inset: 0;
+      background: rgba(0,0,0,.9);
       display: none;
       align-items: stretch; justify-content: stretch;
       z-index: 10000;
@@ -985,41 +981,6 @@ let matrixRefreshIntervalId = null;
 let matrixRefreshInProgress = false;
 let matrixCountdownSeconds = 0;
 let matrixResizeHandler = null;
-let matrixViewportHandler = null;
-
-function syncMatrixViewportBounds() {
-  const viewport = window.visualViewport;
-  const top = viewport?.offsetTop || 0;
-  const left = viewport?.offsetLeft || 0;
-  const width = viewport?.width || window.innerWidth;
-  const height = viewport?.height || window.innerHeight;
-  matrixBackdrop.style.setProperty('--matrix-viewport-top', `${top}px`);
-  matrixBackdrop.style.setProperty('--matrix-viewport-left', `${left}px`);
-  matrixBackdrop.style.setProperty('--matrix-viewport-width', `${width}px`);
-  matrixBackdrop.style.setProperty('--matrix-viewport-height', `${height}px`);
-}
-
-function startMatrixViewportSync() {
-  syncMatrixViewportBounds();
-  if (matrixViewportHandler) return;
-  matrixViewportHandler = () => {
-    syncMatrixViewportBounds();
-    applyMatrixLayout();
-  };
-  window.addEventListener('resize', matrixViewportHandler, { passive: true });
-  window.addEventListener('scroll', matrixViewportHandler, { passive: true });
-  window.visualViewport?.addEventListener('resize', matrixViewportHandler, { passive: true });
-  window.visualViewport?.addEventListener('scroll', matrixViewportHandler, { passive: true });
-}
-
-function stopMatrixViewportSync() {
-  if (!matrixViewportHandler) return;
-  window.removeEventListener('resize', matrixViewportHandler);
-  window.removeEventListener('scroll', matrixViewportHandler);
-  window.visualViewport?.removeEventListener('resize', matrixViewportHandler);
-  window.visualViewport?.removeEventListener('scroll', matrixViewportHandler);
-  matrixViewportHandler = null;
-}
 const qualityTimers = new Map();
 
 /* --- Player helpers --- */
@@ -1570,7 +1531,6 @@ function openMatrix() {
     return;
   }
 
-  startMatrixViewportSync();
   matrixBackdrop.style.display = 'flex';
   document.body.style.overflow = 'hidden';
 
@@ -1777,8 +1737,6 @@ function closeMatrix() {
   matrixCountdownSeconds = 0;
   matrixRefreshCountdownEl.textContent = '';
 
-  stopMatrixViewportSync();
-  document.body.style.overflow = '';
   window.location.reload();
 }
 


### PR DESCRIPTION
### Motivation
- The previous change attempted to track `window.visualViewport` to eliminate a viewport gap for the matrix modal, but it introduced unstable layout behavior on mobile and did not reliably fix the visible gap. 
- Revert to the simpler, known-working overlay behavior so users are not affected by transient layout recalculations during browser chrome/keyboard transitions.
- Restore a stable baseline to allow targeted diagnosis and smaller scoped fixes.

### Description
- Restored `.matrix-backdrop` CSS to a simple fixed full-viewport overlay using `position: fixed; inset: 0;` and the original translucent background instead of dynamic `top/left/width/height` properties. 
- Removed `matrixViewportHandler`, `syncMatrixViewportBounds`, `startMatrixViewportSync`, and `stopMatrixViewportSync` functions and their event listener wiring. 
- Removed the calls that started/stopped viewport synchronization from `openMatrix()` and `closeMatrix()` so the modal returns to the previous resize-handler-only lifecycle and body overflow locking.

### Testing
- Ran a small automated check with `python3` that asserts `visualViewport` sync identifiers are not present and that the `.matrix-backdrop` contains `position: fixed; inset: 0;` and `background: rgba(0,0,0,.9);`, and the script check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55630ee65c8332aa96560538355973)