### PR TITLE
Add full-page `matrix-page-mode` and adjust overflow for matrix overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,10 +150,28 @@
       align-items: stretch; justify-content: stretch;
       z-index: 10000;
     }
+    body.matrix-page-mode {
+      padding: 0;
+      background: #000;
+    }
+    body.matrix-page-mode .container,
+    body.matrix-page-mode > .grid {
+      display: none;
+    }
+    body.matrix-page-mode .matrix-backdrop {
+      position: static;
+      min-height: 100vh;
+      background: #000;
+      z-index: auto;
+    }
     .matrix-modal {
       position: absolute; inset: 0;
       display: flex; flex-direction: column;
       background: #000;
+    }
+    body.matrix-page-mode .matrix-modal {
+      position: relative;
+      min-height: 100vh;
     }
     .matrix-header {
       position:relative;
@@ -1531,8 +1549,9 @@ function openMatrix() {
     return;
   }
 
+  document.body.classList.add('matrix-page-mode');
   matrixBackdrop.style.display = 'flex';
-  document.body.style.overflow = 'hidden';
+  document.body.style.overflow = '';
 
   if (!matrixInitialized) {
     /* First open — build tiles and create players */


### PR DESCRIPTION
### Motivation
- Provide a dedicated full-page mode for the matrix overlay so the viewer grid can be shown as a standalone, immersive page.
- Avoid layout and scrolling conflicts with the underlying site when the matrix is opened.

### Description
- Add a `.matrix-page-mode` body class with styles to set a black background, remove page padding, and hide the main `.container` and top-level `.grid` elements.
- Adjust `.matrix-backdrop` and `.matrix-modal` rules for full-page behavior by making the backdrop static and the modal relative with `min-height: 100vh`.
- Enable the page mode by calling `document.body.classList.add('matrix-page-mode')` in `openMatrix()` when the matrix is shown.
- Change `document.body.style.overflow` from `'hidden'` to an empty string in `openMatrix()` to restore default scrolling behavior instead of forcibly disabling it.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55657956c8833294593416e6378f0a)