### PR TITLE
Restore matrix overlay fixed-viewport behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,28 +150,10 @@
       align-items: stretch; justify-content: stretch;
       z-index: 10000;
     }
-    body.matrix-page-mode {
-      padding: 0;
-      background: #000;
-    }
-    body.matrix-page-mode .container,
-    body.matrix-page-mode > .grid {
-      display: none;
-    }
-    body.matrix-page-mode .matrix-backdrop {
-      position: static;
-      min-height: 100vh;
-      background: #000;
-      z-index: auto;
-    }
     .matrix-modal {
       position: absolute; inset: 0;
       display: flex; flex-direction: column;
       background: #000;
-    }
-    body.matrix-page-mode .matrix-modal {
-      position: relative;
-      min-height: 100vh;
     }
     .matrix-header {
       position:relative;
@@ -1549,9 +1531,8 @@ function openMatrix() {
     return;
   }
 
-  document.body.classList.add('matrix-page-mode');
   matrixBackdrop.style.display = 'flex';
-  document.body.style.overflow = '';
+  document.body.style.overflow = 'hidden';
 
   if (!matrixInitialized) {
     /* First open — build tiles and create players */


### PR DESCRIPTION
### Motivation
- The matrix overlay was unintentionally converted to participate in normal page flow which could collapse the grid into a narrow column instead of a full-viewport modal. 
- The intent is to keep the matrix as a fixed, full-screen overlay so embedded players maintain their expected layout and sizing. 
- Preventing page scroll when the matrix is open improves the modal UX and avoids layout reflow issues.

### Description
- Removed the `body.matrix-page-mode` CSS rules that changed `.matrix-backdrop` to `position: static` and hid the main page content, restoring the overlay to `position: fixed; inset: 0` behavior. 
- Stopped toggling the `matrix-page-mode` class in `openMatrix()` and instead set `document.body.style.overflow = 'hidden'` when opening the matrix. 
- Ensured the matrix is shown by setting `matrixBackdrop.style.display = 'flex'` and left `.matrix-modal` as `position: absolute; inset: 0` so the grid fills the overlay correctly.

### Testing
- Ran `git diff --check HEAD^ HEAD` and the check completed without issues. 
- Ran `git status --short` to validate the working tree state and it reported the expected changes. 
- No automated layout tests are present; changes were limited to CSS/JS to restore overlay behavior and the two checks above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5568382e0c8332b7a89201f18b954d)